### PR TITLE
Gracefully handle missing Builtins.

### DIFF
--- a/src/pages/chip.ts
+++ b/src/pages/chip.ts
@@ -19,7 +19,7 @@ import { FileSystem } from "@davidsouther/jiffies/fs.js";
 import { Err, isErr, Ok, unwrap } from "@davidsouther/jiffies/result.js";
 import { Pinout } from "../components/pinout.js";
 import { Runbar } from "../components/runbar.js";
-import { LOW, Pin } from "../simulator/chip/chip.js";
+import { Low, LOW, Pin } from "../simulator/chip/chip.js";
 import { Timer } from "../simulator/timer.js";
 import { Chip as SimChip } from "../simulator/chip/chip.js";
 import * as make from "../simulator/chip/builder.js";
@@ -98,7 +98,9 @@ export const Chip = () => {
   let project = localStorage["chip/project"] ?? "01";
   let chips: string[] = PROJECTS[project as "01" | "02"];
   let chipName = localStorage["chip/chip"] ?? "And";
-  let chip: SimChip = getBuiltinChip(chipName);
+  let maybeChip = getBuiltinChip(chipName);
+  if (isErr(maybeChip)) statusLine(display(Err(maybeChip)));
+  let chip: SimChip = isErr(maybeChip) ? new Low() : Ok(maybeChip);
 
   setTimeout(async function () {
     await setProject(project);

--- a/src/simulator/chip/builtins/index.ts
+++ b/src/simulator/chip/builtins/index.ts
@@ -1,4 +1,4 @@
-import { assert } from "@davidsouther/jiffies/assert.js";
+import { Err, Ok, Result } from "@davidsouther/jiffies/result";
 import { Chip } from "../chip.js";
 import { Add16 } from "./arithmetic/add_16.js";
 import { ALU, ALUNoStat } from "./arithmetic/alu.js";
@@ -11,7 +11,7 @@ import { Demux } from "./logic/demux.js";
 import { Mux, Mux16 } from "./logic/mux.js";
 import { Nand, Nand16 } from "./logic/nand.js";
 import { Not, Not16 } from "./logic/not.js";
-import { Or, Or8way } from "./logic/or.js";
+import { Or, Or16, Or8way } from "./logic/or.js";
 import { Xor } from "./logic/xor.js";
 
 export { And, And16 } from "./logic/and.js";
@@ -30,11 +30,13 @@ export const REGISTRY = new Map<string, () => Chip>(
     ["And", And],
     ["And16", And16],
     ["Or", Or],
+    ["Or16", Or16],
+    ["Or8way", Or8way],
     ["XOr", Xor],
+    ["XOr16", Xor],
     ["Mux", Mux],
     ["Mux16", Mux16],
     ["Demux", Demux],
-    ["Or8way", Or8way],
     ["HalfAdder", HalfAdder],
     ["FullAdder", FullAdder],
     ["Add16", Add16],
@@ -51,7 +53,9 @@ export const REGISTRY = new Map<string, () => Chip>(
   ])
 );
 
-export function getBuiltinChip(name: string): Chip {
-  assert(REGISTRY.has(name), `Chip ${name} not in builtin registry`);
-  return REGISTRY.get(name)!();
+export function getBuiltinChip(name: string): Result<Chip> {
+  const chip = REGISTRY.get(name);
+  return chip
+    ? Ok(chip())
+    : Err(new Error(`Chip ${name} not in builtin registry`));
 }

--- a/src/simulator/chip/builtins/logic/and.ts
+++ b/src/simulator/chip/builtins/logic/and.ts
@@ -4,8 +4,8 @@ export function and(a: Voltage, b: Voltage): [Voltage] {
   return [a == 1 && b == 1 ? HIGH : LOW];
 }
 
-export function and16(a: number, b: number): number {
-  return a & b & 0xffff;
+export function and16(a: number, b: number): [number] {
+  return [a & b & 0xffff];
 }
 
 export class And extends Chip {
@@ -27,9 +27,9 @@ export class And16 extends Chip {
   }
 
   eval() {
-    this.out().busVoltage = and16(
-      this.in("a").busVoltage,
-      this.in("b").busVoltage
-    );
+    const a = this.in("a").busVoltage;
+    const b = this.in("b").busVoltage;
+    const [n] = and16(a, b);
+    this.out().busVoltage = n;
   }
 }

--- a/src/simulator/chip/builtins/logic/not.ts
+++ b/src/simulator/chip/builtins/logic/not.ts
@@ -4,8 +4,8 @@ export function not(inn: Voltage): [Voltage] {
   return [inn === LOW ? HIGH : LOW];
 }
 
-export function not16(inn: number): number {
-  return ~inn & 0xffff;
+export function not16(inn: number): [number] {
+  return [~inn & 0xffff];
 }
 
 export class Not extends Chip {
@@ -26,6 +26,7 @@ export class Not16 extends Chip {
   }
 
   eval() {
-    this.out().busVoltage = not16(this.in().busVoltage);
+    const [n] = not16(this.in().busVoltage);
+    this.out().busVoltage = n;
   }
 }

--- a/src/simulator/chip/builtins/logic/or.ts
+++ b/src/simulator/chip/builtins/logic/or.ts
@@ -4,6 +4,10 @@ export function or(a: Voltage, b: Voltage): [Voltage] {
   return [a == 1 || b == 1 ? HIGH : LOW];
 }
 
+export function or16(a: number, b: number): [number] {
+  return [(a | b) & 0xffff];
+}
+
 export function or8way(a: number): [Voltage] {
   return [(a & 0xff) == 0 ? LOW : HIGH];
 }
@@ -18,6 +22,19 @@ export class Or extends Chip {
     const b = this.in("b").voltage();
     const [out] = or(a, b);
     this.out().pull(out);
+  }
+}
+
+export class Or16 extends Chip {
+  constructor() {
+    super(["a[16]", "b[16]"], ["out[16"]);
+  }
+
+  eval() {
+    const a = this.in("a").busVoltage;
+    const b = this.in("b").busVoltage;
+    const [out] = or16(a, b);
+    this.out().busVoltage = out;
   }
 }
 

--- a/src/simulator/chip/builtins/logic/xor.ts
+++ b/src/simulator/chip/builtins/logic/xor.ts
@@ -1,7 +1,11 @@
 import { Chip, HIGH, LOW, Voltage } from "../../chip.js";
 
 export function xor(a: Voltage, b: Voltage): [Voltage] {
-  return [(a == 1 && b == 0) || (a == 0 && b == 1) ? HIGH : LOW];
+  return [(a == HIGH && b == LOW) || (a == LOW && b == HIGH) ? HIGH : LOW];
+}
+
+export function xor16(a: number, b: number): [number] {
+  return [(a ^ b) & 0xffff];
 }
 
 export class Xor extends Chip {
@@ -14,5 +18,18 @@ export class Xor extends Chip {
     const b = this.in("b").voltage();
     const [out] = xor(a, b);
     this.out().pull(out);
+  }
+}
+
+export class Xor16 extends Chip {
+  constructor() {
+    super(["a[16]", "b[16]"], ["out[16]"]);
+  }
+
+  eval() {
+    const a = this.in("a").busVoltage;
+    const b = this.in("b").busVoltage;
+    const [out] = xor16(a, b);
+    this.out().busVoltage = out;
   }
 }

--- a/src/simulator/chip/chip.ts
+++ b/src/simulator/chip/chip.ts
@@ -4,7 +4,7 @@ import {
   assertString,
 } from "@davidsouther/jiffies/assert.js";
 import { range } from "@davidsouther/jiffies/range.js";
-import { bin, nand16 } from "../../util/twos.js";
+import { bin } from "../../util/twos.js";
 
 export const HIGH = 1;
 export const LOW = 0;
@@ -108,6 +108,13 @@ export class TrueBus extends Bus {
   voltage(_ = 0): Voltage {
     return HIGH;
   }
+
+  set busVoltage(voltage: number) {
+    // Noop
+  }
+  get busVoltage(): number {
+    return 0xffff;
+  }
 }
 
 export class FalseBus extends Bus {
@@ -118,6 +125,12 @@ export class FalseBus extends Bus {
   pullLow(_ = 0) {}
   voltage(_ = 0): Voltage {
     return LOW;
+  }
+  set busVoltage(voltage: number) {
+    // Noop
+  }
+  get busVoltage(): number {
+    return 0x0000;
   }
 }
 
@@ -283,6 +296,20 @@ export class Chip {
 
   tock() {
     this.eval();
+  }
+}
+
+export class Low extends Chip {
+  constructor() {
+    super([], ["out"]);
+    this.outs.insert(new FalseBus("out"));
+  }
+}
+
+export class High extends Chip {
+  constructor() {
+    super([], ["out"]);
+    this.outs.insert(new TrueBus("out"));
   }
 }
 


### PR DESCRIPTION
1. Change `getBuiltinChip` from Chip|never to Result<Chip>
2. When loading with a missing chip, start with `Low` and then attempt to parse saved data.
3. Add Or16 (a common project chip) to Builtins (and also Xor16)
4. Normalized return values for And16, Or16
5. (Misc) Added busVoltage to TrueBus and FalseBus