### PR TITLE
Feat/prefer builtin

### DIFF
--- a/src/components/editor.scss
+++ b/src/components/editor.scss
@@ -1,7 +1,15 @@
 .Editor {
   display: flex;
+  position: relative;
 
   textarea {
     flex: 1;
+  }
+
+  .overlay {
+    position: absolute;
+    inset: 0;
+    background-color: var(--form-element-disabled-background-color);
+    opacity: var(--form-element-disabled-opacity);
   }
 }

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -154,15 +154,7 @@ const Monaco = ({
         language={language}
         onMount={onMount}
       />
-      {disabled && (
-        <div
-          style={{
-            position: "relative",
-            inset: 0,
-            backgroundColor: "hsla(0, 0, 75%, 75%)",
-          }}
-        />
-      )}
+      {disabled && <div className="overlay" />}
     </>
   );
 };

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -105,7 +105,7 @@ const Monaco = ({
 
   useEffect(() => {
     if (editor.current === undefined) return;
-    editor.current.updateOptions({ readOnly: !disabled });
+    editor.current.updateOptions({ readOnly: disabled });
   }, [editor, disabled]);
 
   useEffect(() => {
@@ -147,12 +147,23 @@ const Monaco = ({
   }, [error, editor, monaco, language]);
 
   return (
-    <MonacoEditor
-      value={value}
-      onChange={(v = "") => onChange(v)}
-      language={language}
-      onMount={onMount}
-    />
+    <>
+      <MonacoEditor
+        value={value}
+        onChange={(v = "") => onChange(v)}
+        language={language}
+        onMount={onMount}
+      />
+      {disabled && (
+        <div
+          style={{
+            position: "relative",
+            inset: 0,
+            backgroundColor: "hsla(0, 0, 75%, 75%)",
+          }}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -39,15 +39,18 @@ const Textarea = ({
   value,
   onChange,
   language,
+  disabled = false,
 }: {
   value: string;
   onChange: (value: string) => void;
   language: string;
+  disabled?: boolean;
 }) => {
   const [text, setText] = useState(value);
   return (
     <textarea
       data-testid={`editor-${language}`}
+      disabled={disabled}
       value={text}
       onChange={(e) => {
         const value = e.target?.value;
@@ -63,11 +66,13 @@ const Monaco = ({
   onChange,
   language,
   error,
+  disabled = false,
 }: {
   value: string;
   onChange: (value: string) => void;
   language: string;
   error?: ohm.MatchResult | undefined;
+  disabled?: boolean;
 }) => {
   const { theme } = useContext(AppContext);
   const monaco = useMonaco();
@@ -97,6 +102,11 @@ const Monaco = ({
       theme: isDark ? "vs-dark" : "vs",
     });
   }, [editor, theme]);
+
+  useEffect(() => {
+    if (editor.current === undefined) return;
+    editor.current.updateOptions({ readOnly: !disabled });
+  }, [editor, disabled]);
 
   useEffect(() => {
     if (editor.current === undefined) return;
@@ -148,12 +158,14 @@ const Monaco = ({
 
 export const Editor = ({
   className = "",
+  disabled = false,
   value,
   onChange,
   grammar,
   language,
 }: {
   className?: string;
+  disabled?: boolean;
   value: string;
   onChange: (source: string) => void;
   grammar: ohm.Grammar;
@@ -189,10 +201,16 @@ export const Editor = ({
           onChange={onChangeCB}
           language={language}
           error={error}
+          disabled={disabled}
         />
       ) : (
         <>
-          <Textarea value={value} onChange={onChangeCB} language={language} />
+          <Textarea
+            value={value}
+            onChange={onChangeCB}
+            language={language}
+            disabled={disabled}
+          />
           <ErrorPanel error={error} />
         </>
       )}

--- a/src/pages/chip.store.ts
+++ b/src/pages/chip.store.ts
@@ -135,6 +135,20 @@ export class ChipPageStore {
     // });
   }
 
+  replaceChip(chip: Ok<SimChip>) {
+    // Store current inPins
+    const inPins = this.chip.ins;
+    this.chip = Ok(chip);
+    for (const [pin, { busVoltage }] of inPins) {
+      if (this.chip.ins.has(pin)) {
+        this.chip.ins.get(pin)!.busVoltage = busVoltage;
+      }
+    }
+    this.chip.eval();
+    this.next();
+    return true;
+  }
+
   useBuiltin() {
     const nextChip = getBuiltinChip(this.chipName);
     if (isErr(nextChip)) {
@@ -143,9 +157,7 @@ export class ChipPageStore {
       );
       return false;
     }
-    this.chip = Ok(nextChip);
-    this.next();
-    return true;
+    return this.replaceChip(nextChip);
   }
 
   reset() {
@@ -201,10 +213,8 @@ export class ChipPageStore {
       this.statusLine(display(Err(maybeChip)));
       return;
     }
-    this.chip = Ok(maybeChip);
     this.statusLine(t`Compiled ${this.chip.name}`);
-    this.chip.eval();
-    this.next();
+    this.replaceChip(maybeChip);
   }
 
   async saveChip(text: string) {

--- a/src/pages/chip.store.ts
+++ b/src/pages/chip.store.ts
@@ -135,6 +135,19 @@ export class ChipPageStore {
     // });
   }
 
+  useBuiltin() {
+    const nextChip = getBuiltinChip(this.chipName);
+    if (isErr(nextChip)) {
+      this.statusLine(
+        `Failed to load builtin ${this.chipName}: ${display(Err(nextChip))}`
+      );
+      return false;
+    }
+    this.chip = Ok(nextChip);
+    this.next();
+    return true;
+  }
+
   reset() {
     Clock.get().reset();
     this.chip?.reset();

--- a/src/pages/chip.store.ts
+++ b/src/pages/chip.store.ts
@@ -258,6 +258,7 @@ export class ChipPageStore {
 
     try {
       this.compileChip();
+      this.reset();
     } catch (e) {
       this.statusLine(display(e));
     }

--- a/src/pages/chip.tsx
+++ b/src/pages/chip.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 import { Trans } from "@lingui/macro";
 
 import "./chip.scss";
@@ -17,6 +17,7 @@ import { TST } from "../languages/tst";
 import { CMP } from "../languages/cmp";
 import { Clockface } from "../components/clockface";
 import { Visualizations } from "../components/chips/visualizations";
+import { REGISTRY } from "../simulator/chip/builtins";
 
 let store = new ChipPageStore();
 const clock = Clock.get();
@@ -41,6 +42,7 @@ export const Chip = () => {
         setInPins(reducePins(chip.ins));
         setOutPins(reducePins(chip.outs));
         setInternalPins(reducePins(chip.pins));
+        setHasBuiltin(REGISTRY.has(chip.name ?? ""));
       })
     );
 
@@ -98,6 +100,8 @@ export const Chip = () => {
   const [hdlFile, setHdlFile] = useState(store.files.hdl);
   const [tstFile, setTstFile] = useState(store.files.tst);
 
+  // const hasBuiltin = useMemo(() => REGISTRY.has(chip), [chip]);
+  const [hasBuiltin, setHasBuiltin] = useState(false);
   const [useBuiltin, setUseBuiltin] = useState(false);
   const toggleUseBuiltin = async () => {
     if (useBuiltin) {
@@ -186,15 +190,17 @@ export const Chip = () => {
       <header>
         <div tabIndex={0}>HDL</div>
         <fieldset>
-          <label>
-            <input
-              type="checkbox"
-              role="switch"
-              checked={useBuiltin}
-              onChange={toggleUseBuiltin}
-            />
-            <Trans>Builtin</Trans>
-          </label>
+          {hasBuiltin && (
+            <label>
+              <input
+                type="checkbox"
+                role="switch"
+                checked={useBuiltin}
+                onChange={toggleUseBuiltin}
+              />
+              <Trans>Builtin</Trans>
+            </label>
+          )}
         </fieldset>
         <fieldset role="group">
           <button onClick={compile} onKeyDown={compile} disabled={useBuiltin}>

--- a/src/pages/chip.tsx
+++ b/src/pages/chip.tsx
@@ -98,6 +98,17 @@ export const Chip = () => {
   const [hdlFile, setHdlFile] = useState(store.files.hdl);
   const [tstFile, setTstFile] = useState(store.files.tst);
 
+  const [useBuiltin, setUseBuiltin] = useState(false);
+  const toggleUseBuiltin = async () => {
+    if (useBuiltin) {
+      await compile();
+      setUseBuiltin(false);
+    } else {
+      let builtin = store.useBuiltin();
+      setUseBuiltin(builtin);
+    }
+  };
+
   function clearOutput() {
     setOutText("");
   }
@@ -120,8 +131,10 @@ export const Chip = () => {
   }
 
   async function execute() {
-    await setFiles();
-    await store.compileChip();
+    if (!useBuiltin) {
+      await setFiles();
+      await store.compileChip();
+    }
     await store.runTest();
   }
 
@@ -206,6 +219,7 @@ export const Chip = () => {
           onChange={setHdlFile}
           grammar={HDL.parser}
           language={"hdl"}
+          disabled={!useBuiltin}
         />
       </main>
     </article>
@@ -232,8 +246,16 @@ export const Chip = () => {
   );
   const internalPanel = (
     <article className="_internal_panel no-shadow panel">
-      <header tabIndex={0}>
-        <Trans>Internal pins</Trans>
+      <header>
+        <div tabIndex={0}>
+          <Trans>Internal pins</Trans>
+        </div>
+        <fieldset role="group">
+          <label>
+            <input type="checkbox" onChange={toggleUseBuiltin} />
+            <Trans>Builtin</Trans>
+          </label>
+        </fieldset>
       </header>
       <Pinout pins={internalPins} />
     </article>

--- a/src/pages/chip.tsx
+++ b/src/pages/chip.tsx
@@ -233,7 +233,7 @@ export const Chip = () => {
           onChange={setHdlFile}
           grammar={HDL.parser}
           language={"hdl"}
-          disabled={!useBuiltin}
+          disabled={useBuiltin}
         />
       </main>
     </article>

--- a/src/pages/chip.tsx
+++ b/src/pages/chip.tsx
@@ -185,12 +185,26 @@ export const Chip = () => {
     <article className="_hdl_panel no-shadow panel">
       <header>
         <div tabIndex={0}>HDL</div>
-        {/* <fieldset className="button-group"> */}
+        <fieldset>
+          <label>
+            <input
+              type="checkbox"
+              role="switch"
+              checked={useBuiltin}
+              onChange={toggleUseBuiltin}
+            />
+            <Trans>Builtin</Trans>
+          </label>
+        </fieldset>
         <fieldset role="group">
-          <button onClick={compile} onKeyDown={compile}>
+          <button onClick={compile} onKeyDown={compile} disabled={useBuiltin}>
             <Trans>Eval</Trans>
           </button>
-          <button onClick={onSaveChip} onKeyDown={onSaveChip}>
+          <button
+            onClick={onSaveChip}
+            onKeyDown={onSaveChip}
+            disabled={useBuiltin}
+          >
             <Trans>Save</Trans>
           </button>
           <button
@@ -250,12 +264,7 @@ export const Chip = () => {
         <div tabIndex={0}>
           <Trans>Internal pins</Trans>
         </div>
-        <fieldset role="group">
-          <label>
-            <input type="checkbox" onChange={toggleUseBuiltin} />
-            <Trans>Builtin</Trans>
-          </label>
-        </fieldset>
+        <fieldset role="group"></fieldset>
       </header>
       <Pinout pins={internalPins} />
     </article>

--- a/src/simulator/chip/builtins/computer/computer.tsx
+++ b/src/simulator/chip/builtins/computer/computer.tsx
@@ -72,7 +72,7 @@ export class Memory extends ClockedChip {
   private address = 0;
 
   constructor() {
-    super(["in[16]", "load", "address[16])"], ["out[16]"], "Memory");
+    super(["in[16]", "load", "address[15])"], ["out[16]"], "Memory");
     this.parts.add(this.ram);
     this.parts.add(this.screen);
     this.parts.add(this.keyboard);


### PR DESCRIPTION
Adds a toggle to the HDL header to use the builtin version of the chip, to explore the expected input and output of the chips. Also has a number of convenience features for this change. See #79 