### PR TITLE
Move clock buttons to Chip header.

### DIFF
--- a/src/components/pinout.tsx
+++ b/src/components/pinout.tsx
@@ -4,7 +4,6 @@ import { range } from "@davidsouther/jiffies/lib/esm/range";
 
 import "./pinout.scss";
 import { ChipSim } from "../pages/chip.store";
-import { Clockface } from "./clockface";
 
 export interface ImmPin {
   bits: [number, Voltage][];
@@ -32,15 +31,11 @@ export interface PinoutPins {
 export const FullPinout = (props: {
   sim: ChipSim;
   toggle: (pin: ChipPin, i: number | undefined) => void;
-  clockActions: { toggle(): void; reset(): void };
 }) => {
   const { inPins, outPins, internalPins } = props.sim;
   return (
     <table className="pinout">
       <tbody>
-        {props.sim.clocked && (
-          <ClockPinoutBlock clockActions={props.clockActions} />
-        )}
         <PinoutBlock
           pins={inPins}
           header={plural(inPins.length, {
@@ -87,37 +82,6 @@ export const PinoutBlock = (
         </td>
       </tr>
     ))}
-  </>
-);
-
-export const ClockPinoutBlock = ({
-  clockActions,
-}: {
-  clockActions: { toggle(): void; reset(): void };
-}) => (
-  <>
-    <tr>
-      <th colSpan={2}>
-        <Trans>Clock Pin</Trans>
-      </th>
-    </tr>
-    <tr>
-      <td>
-        <Trans>Clock</Trans>
-      </td>
-      <td className="flex row justify-between">
-        <fieldset role="group">
-          <button onClick={clockActions.toggle} style={{ maxWidth: "initial" }}>
-            <Clockface />
-          </button>
-        </fieldset>
-        <fieldset role="group">
-          <button onClick={clockActions.reset} style={{ maxWidth: "initial" }}>
-            <Trans>Reset</Trans>
-          </button>
-        </fieldset>
-      </td>
-    </tr>
   </>
 );
 

--- a/src/pages/chip.store.ts
+++ b/src/pages/chip.store.ts
@@ -294,6 +294,7 @@ export function makeChipStore(
           nextChip.ins.get(pin)!.busVoltage = busVoltage;
         }
       }
+      clock.reset();
       nextChip.eval();
       chip = nextChip;
       dispatch.current({ action: "updateChip" });

--- a/src/pages/chip.tsx
+++ b/src/pages/chip.tsx
@@ -15,6 +15,7 @@ import { Accordian, Panel } from "../components/shell/panel";
 import { Runbar } from "../components/runbar";
 import { Timer } from "../simulator/timer";
 import { useStateInitializer } from "../util/react";
+import { Clockface } from "../components/clockface";
 
 export const Chip = () => {
   const { state, actions, dispatch } = useChipPageStore();
@@ -88,9 +89,6 @@ export const Chip = () => {
 
   const selectors = (
     <>
-      <div>
-        <Trans>Chip</Trans>
-      </div>
       <fieldset role="group">
         <select
           value={state.controls.project}
@@ -118,14 +116,8 @@ export const Chip = () => {
             </option>
           ))}
         </select>
-      </fieldset>
-      <fieldset role="group">
-        <button
-          onClick={actions.eval}
-          onKeyDown={actions.eval}
-          disabled={!state.sim.pending}
-        >
-          <Trans>Eval</Trans>
+        <button className="flex-0" onClick={saveChip} disabled={useBuiltin}>
+          <Trans>Save</Trans>
         </button>
       </fieldset>
     </>
@@ -149,11 +141,7 @@ export const Chip = () => {
               </label>
             )}
           </fieldset>
-          <fieldset role="group">
-            <button onClick={saveChip} disabled={useBuiltin}>
-              <Trans>Save</Trans>
-            </button>
-          </fieldset>
+          {selectors}
         </>
       }
     >
@@ -171,17 +159,50 @@ export const Chip = () => {
     </Panel>
   );
 
+  const chipButtons = (
+    <fieldset role="group">
+      <button
+        onClick={actions.eval}
+        onKeyDown={actions.eval}
+        disabled={!state.sim.pending}
+      >
+        <Trans>Eval</Trans>
+      </button>
+      <button
+        onClick={clockActions.toggle}
+        style={{ maxWidth: "initial" }}
+        disabled={!state.sim.clocked}
+      >
+        <Trans>Clock</Trans>:{"\u00a0"}
+        <Clockface />
+      </button>
+      <button
+        onClick={clockActions.reset}
+        style={{ maxWidth: "initial" }}
+        disabled={!state.sim.clocked}
+      >
+        <Trans>Reset</Trans>
+      </button>
+    </fieldset>
+  );
+
   const pinsPanel = (
-    <Panel className="_parts_panel" header={selectors}>
+    <Panel
+      className="_parts_panel"
+      header={
+        <>
+          <div>
+            <Trans>Chip</Trans>
+          </div>
+          {chipButtons}
+        </>
+      }
+    >
       {state.sim.invalid ? (
         <Trans>Invalid Chip</Trans>
       ) : (
         <>
-          <FullPinout
-            sim={state.sim}
-            toggle={actions.toggle}
-            clockActions={clockActions}
-          />
+          <FullPinout sim={state.sim} toggle={actions.toggle} />
           <Accordian summary={<Trans>Visualizations</Trans>} open={true}>
             <main>
               <Visualizations parts={state.sim.parts} />


### PR DESCRIPTION
The clock is considered global, so we don't want it as a pin chip.

Closes #131 