### PR TITLE
Diff table feedback

### DIFF
--- a/web/src/components/difftable.tsx
+++ b/web/src/components/difftable.tsx
@@ -47,7 +47,7 @@ export const DiffTable = ({
   const cmpData = Ok(compare);
   const outData = Ok(output);
   let failures = 0;
-  const table = range(0, Math.max(cmpData.length, outData.length)).map((i) => {
+  const table = range(0, Math.min(cmpData.length, outData.length)).map((i) => {
     const cmpI = cmpData[i] ?? [];
     const outI = outData[i] ?? [];
     return range(0, Math.max(cmpI.length, outI.length))
@@ -69,11 +69,14 @@ export const DiffTable = ({
   return (
     <div className={"scroll-x " + className}>
       <p>
-        <Plural
-          value={failures}
-          one={`${failures} failure`}
-          other={`${failures} failures`}
-        />
+        {failures > 0 && (
+          <Plural
+            value={failures}
+            zero={""}
+            one={`${failures} failure`}
+            other={`${failures} failures`}
+          />
+        )}
       </p>
       <table
         style={{
@@ -107,14 +110,12 @@ const DiffCell = ({
   return pass ? (
     <>
       <td>{cmp}</td>
-      <td></td>
     </>
   ) : (
     <>
       <td>
         <ins>{cmp}</ins>
-      </td>
-      <td>
+        <br />
         <del>{out}</del>
       </td>
     </>

--- a/web/src/components/pico/pico.scss
+++ b/web/src/components/pico/pico.scss
@@ -5,13 +5,18 @@
   }
 
   :root {
-    --line-height: 1.25; /* 1.5 */
-    --spacing: 0.25rem; /* 1rem */
-    --typography-spacing-vertical: 1.15rem; /* 1.5rem */
+    --line-height: 1.25;
+    /* 1.5 */
+    --spacing: 0.25rem;
+    /* 1rem */
+    --typography-spacing-vertical: 1.15rem;
+    /* 1.5rem */
     --grid-spacing-horizontal: var(--spacing);
     --grid-spacing-vertical: var(--spacing);
-    --form-element-spacing-vertical: 0.15rem; /* .75rem */
-    --form-element-spacing-horizontal: 0.25rem; /* 1rem */
+    --form-element-spacing-vertical: 0.15rem;
+    /* .75rem */
+    --form-element-spacing-horizontal: 0.25rem;
+    /* 1rem */
     --font-family: Poppins, system-ui, -apple-system, "Segoe UI", Roboto, Oxygen,
       Ubuntu, Cantarell, "Noto Sans", sans-serif, "Apple Color Emoji",
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
@@ -151,5 +156,9 @@
 
   nav li {
     padding: 0 var(--nav-link-spacing-horizontal);
+  }
+
+  td {
+    vertical-align: top;
   }
 }


### PR DESCRIPTION
Only show errors for completed out lines. 
Show errors stacked in a single cell.

Closes #127 

A passing diff table

<img width="502" alt="image" src="https://user-images.githubusercontent.com/498712/195749945-a0ee81ea-9c90-4ef4-8cbc-ada19e5436e0.png">


A diff table with failures

<img width="506" alt="image" src="https://user-images.githubusercontent.com/498712/195750001-4a633420-3723-4eab-99b8-ada0dcecf90b.png">


For scrolling the table, I think this is the best we're going to get from the web layout. Having the flexible panels in VSCode will be a plus.