### PR TITLE
chore: Prettier config

### DIFF
--- a/.prettierconfig.yaml
+++ b/.prettierconfig.yaml
@@ -2,23 +2,23 @@ arrowParens: "always" # default
 bracketSameLine: false # default
 bracketSpacing: true # default
 embeddedLanguageFormatting: "auto" # default
-endOfLine: "lf" # default
+endOfLine: "auto" # default is "lf"
 filepath: "" # default
 htmlWhitespaceSensitivity: "css" # default
 insertPragma: false # default
-jsxBracketSameLine: false # default
+# jsxBracketSameLine: false # deprecated
 jsxSingleQuote: false # default
 parser: "" # default
-printWidth: 80 # Default
+printWidth: 80 # default
 proseWrap: "preserve" # default
 quoteProps: "as-needed" # default
-rangeEnd: Infinity # default
+# rangeEnd: Infinity # default; "Infinity" can't be read as int
 rangeStart: 0 # default
 requirePragma: false # default
 semi: true # default
-singleAttributePerLine: "false" # default
+singleAttributePerLine: false # default
 singleQuote: false # default
 tabWidth: 2 # default
-trailingComma: "es5" # default
+trailingComma: "all" # default is "es5"
 useTabs: false # default
 vueIndentScriptAndStyle: false # default

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "concurrently": "^9.0.1",
         "cross-env": "^7.0.3",
+        "prettier": "^3.4.2",
         "shx": "^0.3.4"
       },
       "engines": {
@@ -16614,9 +16615,10 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "precheck": "npm -w web run extract && npm -w web run lingui",
     "check": "npm run check:format && npm run check:types && npm run check:lint",
     "clean": "shx rm -rf **/node_modules **/tsconfig.tsbuildinfo **/build",
-    "format": "prettier --write cli/src components/src extension/src projects/src runner/src simulator/src web/src",
+    "format": "prettier --config .prettierconfig.yaml --write cli/src components/src extension/src projects/src runner/src simulator/src web/src",
     "fix": "eslint --fix cli/src components/src extension/src projects/src runner/src simulator/src web/src",
-    "check:format": "prettier --ignore-unknown --check cli/src components/src extension/src projects/src runner/src simulator/src web/src web/public",
+    "check:format": "prettier --ignore-unknown --config .prettierconfig.yaml --check cli/src components/src extension/src projects/src runner/src simulator/src web/src web/public",
     "check:lint": "eslint --no-error-on-unmatched-pattern cli/src components/src extension/src projects/src runner/src simulator/src web/src web/public",
     "precheck:types": "npm run build -w projects && npm run build -w runner && npm run build -w simulator && npm run build -w components",
     "check:types": "tsc --build tsconfig.json",
@@ -54,6 +54,7 @@
   "devDependencies": {
     "concurrently": "^9.0.1",
     "cross-env": "^7.0.3",
+    "prettier": "^3.4.2",
     "shx": "^0.3.4"
   }
 }

--- a/web/src/pico/pico.scss
+++ b/web/src/pico/pico.scss
@@ -18,8 +18,8 @@
     /* .75rem */
     --form-element-spacing-horizontal: 0.25rem;
     /* 1rem */
-    --font-family: Poppins, system-ui, -apple-system, "Segoe UI", Roboto, Oxygen,
-      Ubuntu, Cantarell, "Noto Sans", sans-serif, "Apple Color Emoji",
+    --font-family: Poppins, system-ui, -apple-system, "Segoe UI", Roboto,
+      Oxygen, Ubuntu, Cantarell, "Noto Sans", sans-serif, "Apple Color Emoji",
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --font-size-monospace: 16px;
     --font-family-monospace: "JetBrains Mono", source-code-pro, Menlo, Monaco,


### PR DESCRIPTION
The .prettierconfig.yaml file didn't match the prettier code style that is actually used in this repo. For new contributors, that means that they will get the message "Code style issues found in 145 files" when they try to build the project. That leads to a cancellation of the build process, which results in not being able to "npm start" the project.

I updated the .prettierconfig.yaml to the settings that seem to be used in this repo. The only file that didn't match the settings is web/src/pico/pico.scss, which is included in this PR.
I also updated the scripts "npm run check:format" and "npm run format" to use the updated config file.