### PR TITLE
Add path property for Monaco editor, and wire through all path names.

### DIFF
--- a/web/src/pages/asm.tsx
+++ b/web/src/pages/asm.tsx
@@ -186,6 +186,7 @@ export const Asm = () => {
       >
         <Editor
           value={state.asm}
+          path={state.path??"tmp.asm"}
           error={state.error}
           alwaysRecenter={false}
           onChange={(source: string) => {
@@ -254,6 +255,7 @@ export const Asm = () => {
       >
         <Editor
           value={state.result}
+          path={(state.path??"tmp.asm").replace(/\.asm$/, '.hack')}
           highlight={state.resultHighlight}
           disabled={true}
           onChange={function (_source: string): void {
@@ -313,6 +315,7 @@ export const Asm = () => {
       >
         <Editor
           value={state.compare}
+          path={(state.path??"tmp.asm").replace(/\.asm$/, '.cmp')}
           highlight={state.translating ? state.resultHighlight : undefined}
           highlightType={state.compareError ? "error" : "highlight"}
           alwaysRecenter={false}

--- a/web/src/pages/chip.tsx
+++ b/web/src/pages/chip.tsx
@@ -261,6 +261,7 @@ export const Chip = () => {
         }}
         grammar={HDL.parser}
         language={"hdl"}
+        path={`${state.controls.project}/${state.controls.chipName}.hdl`}
         disabled={state.controls.usingBuiltin || state.controls.chipName == ""}
       />
     </Panel>

--- a/web/src/pages/compiler.tsx
+++ b/web/src/pages/compiler.tsx
@@ -242,6 +242,7 @@ export const Compiler = () => {
             >
               <Editor
                 value={state.files[file]}
+                path={file}
                 onChange={(source: string) => {
                   actions.writeFile(file, source);
                 }}

--- a/web/src/pages/vm.tsx
+++ b/web/src/pages/vm.tsx
@@ -252,6 +252,7 @@ const VM = () => {
       >
         <Editor
           value={state.files.vm}
+          path={path ?? 'vm'}
           onChange={(source: string) => {
             actions.setVm(source);
           }}

--- a/web/src/shell/Monaco.tsx
+++ b/web/src/shell/Monaco.tsx
@@ -70,6 +70,7 @@ export const Monaco = ({
   onChange,
   onCursorPositionChange,
   language,
+  path,
   error,
   disabled = false,
   highlight: currentHighlight,
@@ -83,6 +84,7 @@ export const Monaco = ({
   onChange: Action<string>;
   onCursorPositionChange?: (index: number) => void;
   language: string;
+  path: string;
   error?: CompilationError;
   disabled?: boolean;
   highlight?: Span | number;
@@ -263,8 +265,9 @@ export const Monaco = ({
   return (
     <MonacoEditor
       value={value}
-      onChange={onValueChange}
       language={language}
+      path={path}
+      onChange={onValueChange}
       onMount={onMount}
       height={dynamicHeight ? height : undefined}
     />

--- a/web/src/shell/editor.tsx
+++ b/web/src/shell/editor.tsx
@@ -71,6 +71,7 @@ export const Editor = ({
   onCursorPositionChange,
   grammar,
   language,
+  path,
   highlight,
   highlightType = "highlight",
   customDecorations = [],
@@ -82,6 +83,7 @@ export const Editor = ({
   style?: CSSProperties;
   disabled?: boolean;
   value: string;
+  path: string;
   error?: CompilationError;
   onChange: Action<string>;
   onCursorPositionChange?: (index: number) => void;
@@ -107,6 +109,7 @@ export const Editor = ({
             value={value}
             onChange={onChange}
             onCursorPositionChange={onCursorPositionChange}
+            path={path}
             language={language}
             error={error}
             disabled={disabled}

--- a/web/src/shell/test_panel.tsx
+++ b/web/src/shell/test_panel.tsx
@@ -241,6 +241,7 @@ export const TestPanel = ({
         <Tab title="Test Script" onSelect={() => setSelectedTestTab("tst")}>
           <Editor
             value={tst}
+            path={`${tstName??'test'}.tst`}
             onChange={onChange}
             grammar={TST.parser}
             language={"tst"}
@@ -251,6 +252,7 @@ export const TestPanel = ({
         <Tab title="Compare File" onSelect={() => setSelectedTestTab("cmp")}>
           <Editor
             value={cmp}
+            path={`${tstName??'test'}.cmp`}
             onChange={setCmp}
             grammar={CMP.parser}
             language={"cmp"}
@@ -266,6 +268,7 @@ export const TestPanel = ({
               return;
             }}
             language={"cmp"}
+            path={`${tstName??'test'}.out`}
             disabled={true}
             lineNumberTransform={(_) => ""}
           />
@@ -285,6 +288,7 @@ export const TestPanel = ({
               return;
             }}
             language={""}
+            path="test.txt"
             disabled={true}
             lineNumberTransform={(i) => diffDisplay?.lineNumbers[i - 1] ?? ""}
             customDecorations={diffDisplay?.decorations.map((decoration) => {


### PR DESCRIPTION
Pass `path` property through Web views to Monaco editor.