### PR TITLE
fix: add appropriate A instruction value constraints

### DIFF
--- a/simulator/src/languages/asm.test.ts
+++ b/simulator/src/languages/asm.test.ts
@@ -364,4 +364,20 @@ describe("asm language", () => {
     ];
     expect(bin).toEqual(file);
   });
+
+  it("fails to parse an A instruction with a value too large", () => {
+    expect(() => {
+      const match = grammar.match("@32768", "aInstruction");
+      if (match.succeeded()) {
+        asmSemantics(match).instruction;
+      }
+    }).toThrow(
+      "Line 1: 32768 is invalid for an A instruction (should be 0 to 32767)",
+    );
+  });
+
+  it("fails to parse an A instruction with a negative value", () => {
+    const match = grammar.match("@-1", "aInstruction");
+    expect(match.failed()).toBe(true);
+  });
 });

--- a/simulator/src/languages/asm.ts
+++ b/simulator/src/languages/asm.ts
@@ -149,7 +149,8 @@ function getAsmOp(opN: Node) {
 
 asmSemantics.addAttribute<AsmInstruction>("instruction", {
   aInstruction(_at, name): AsmAInstruction {
-    return A(name.value, span(this.source));
+    if (typeof name.value === "string") return A(name.value, span(this.source));
+    else return A(parseInt(name.value.join(""), 10), span(this.source));
   },
   cInstruction(assignN, opN, jmpN): AsmCInstruction {
     const assign = getAsmAssign(assignN);
@@ -306,8 +307,14 @@ export function emit(asm: Asm): number[] {
     .filter((op): op is number => op !== undefined);
 }
 
-const A = (source: string | number, span?: Span): AsmAInstruction =>
-  typeof source === "string"
+const A = (source: string | number, span?: Span): AsmAInstruction => {
+  if (typeof source === "number" && (source > 32767 || source < 0)) {
+    throw createError(
+      `${source} is invalid for an A instruction (should be 0 to 32767)`,
+      span,
+    );
+  }
+  return typeof source === "string"
     ? {
         type: "A",
         label: source,
@@ -318,6 +325,7 @@ const A = (source: string | number, span?: Span): AsmAInstruction =>
         value: source,
         span,
       };
+};
 
 const C = (
   assign: ASSIGN_ASM,

--- a/simulator/src/languages/base.ts
+++ b/simulator/src/languages/base.ts
@@ -43,6 +43,12 @@ baseSemantics.addAttribute("value", {
   identifier(_, __): string {
     return this.sourceString;
   },
+  _iter(...children) {
+    return children.map((c) => c.value);
+  },
+  _terminal() {
+    return this.sourceString;
+  },
 });
 
 baseSemantics.addAttribute("name", {

--- a/simulator/src/languages/grammars/asm.ohm
+++ b/simulator/src/languages/grammars/asm.ohm
@@ -8,7 +8,7 @@ ASM <: Base {
   identifier := (letter|underscore|dot|dollar|colon) (alnum|underscore|dot|dollar|colon)*
 
   label = openParen identifier closeParen
-  aInstruction = at (identifier | decNumber)
+  aInstruction = at (identifier | digit+)
   cInstruction = assign? op jmp?
 
   assignChar = "A" | "M" | "D"

--- a/simulator/src/languages/grammars/asm.ohm.js
+++ b/simulator/src/languages/grammars/asm.ohm.js
@@ -8,7 +8,7 @@ const asm = `ASM <: Base {
   identifier := (letter|underscore|dot|dollar|colon) (alnum|underscore|dot|dollar|colon)*
 
   label = openParen identifier closeParen
-  aInstruction = at (identifier | decNumber)
+  aInstruction = at (identifier | digit+)
   cInstruction = assign? op jmp?
 
   assignChar = "A" | "M" | "D"


### PR DESCRIPTION
Closes: #631

This PR was opened to add appropriate A instruction value constraints so that web-ide's Assembler makes A instruction with invalid value disable to translate into binary machine code.

- For `@-1` instruction
With referencing the [Ohm-js documentation](https://ohmjs.org/docs/releases/ohm-js-16.0#default-semantic-actions), aInstruction grammar in asm.ohm.js and asm.ohm are changed from `decNumber` to `digit+`.

- For `@32768` instruction
In `A` function of asm.ts, too large invalid value of A instruction detected and then throw an error message which will be showed in StatusLine footer.

The code was tested locally as described in following.

- Manually writing `@-1`, `@32768` in the editor of web-ide's  Assembler and confirm that the assembly code  cause a syntax error, show the error message, and  can not translate them into binary machine code.
- The Assembler can appropriately translate valid Fill.asm code into binary, and then successfully load in CPU Emulator, and the Emulator can run the machine instruction codes with proper functionality, and without any error.
- The Fill.asm can be sucessfully loaded on CPU Emulator's ROM directly in the web-ide, and the translated machine instructions fullfill the vehavior specification properly.

Unit tests are also added, which ensure the Ohm's grammar validation functionality and solving original issues.