### PR TITLE
feat: support custom chips in editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -290,6 +290,22 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "components/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "extension": {
       "name": "@nand2tetris/vscode",
       "version": "0.0.0",
@@ -696,6 +712,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "extension/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "extension/views/hdl": {
@@ -29226,6 +29257,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "web/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -290,22 +290,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "components/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "extension": {
       "name": "@nand2tetris/vscode",
       "version": "0.0.0",
@@ -712,21 +696,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "extension/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "extension/views/hdl": {
@@ -29257,22 +29226,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "web/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     }
   }

--- a/web/src/languages/hdl.test.ts
+++ b/web/src/languages/hdl.test.ts
@@ -1,0 +1,76 @@
+import {
+  HdlLanguage,
+  HdlSignatures,
+  registerCustomChip,
+  resetCustomChips,
+} from "./hdl";
+
+describe("HDL Custom Chip Registration", () => {
+  beforeEach(() => {
+    resetCustomChips();
+  });
+
+  it("should register a custom chip and store its signature", () => {
+    const name = "SuperGate";
+    const signature = "SuperGate(in= , out= );";
+
+    const wasAdded = registerCustomChip(name, signature);
+
+    expect(wasAdded).toBe(true);
+
+    expect(HdlLanguage.chips as string[]).toContain(name);
+
+    expect(HdlSignatures[name]).toBe(signature);
+  });
+
+  it("should not allow overwriting a built-in chip", () => {
+    const originalAndSignature = HdlSignatures["And"];
+    const fakeSignature = "And(wrong= );";
+
+    const wasAdded = registerCustomChip("And", fakeSignature);
+
+    expect(wasAdded).toBe(false);
+    // Ensure the signature remained the original one
+    expect(HdlSignatures["And"]).toBe(originalAndSignature);
+  });
+
+  it("should return false if the chip and signature are already registered", () => {
+    const name = "MyMux";
+    const sig = "MyMux(a=, b=, out=);";
+
+    registerCustomChip(name, sig);
+    const secondAttempt = registerCustomChip(name, sig);
+
+    expect(secondAttempt).toBe(false);
+  });
+
+  it("should update the signature if the name exists but the signature changed", () => {
+    const name = "FlexibleGate";
+    const sig1 = "FlexibleGate(a= );";
+    const sig2 = "FlexibleGate(a= , b= );";
+
+    registerCustomChip(name, sig1);
+    const wasUpdated = registerCustomChip(name, sig2);
+
+    expect(wasUpdated).toBe(true);
+    expect(HdlSignatures[name]).toBe(sig2);
+  });
+
+  it("should fully remove custom chips and restore defaults on reset", () => {
+    const customName = "TemporaryChip";
+    registerCustomChip(customName, "TemporaryChip(x= );");
+
+    expect(HdlSignatures).toHaveProperty(customName);
+
+    const wasReset = resetCustomChips();
+    expect(wasReset).toBe(true);
+
+    // Verify custom chip is gone from both places
+    expect(HdlLanguage.chips as string[]).not.toContain(customName);
+    expect(HdlSignatures).not.toHaveProperty(customName);
+
+    // Verify built-ins still exist
+    expect(HdlSignatures).toHaveProperty("Nand");
+    expect(HdlLanguage.chips as string[]).toContain("Nand");
+  });
+});

--- a/web/src/languages/hdl.ts
+++ b/web/src/languages/hdl.ts
@@ -116,7 +116,7 @@ export const HdlLanguage: monaco.languages.IMonarchLanguage = {
   },
 };
 
-const HdlSignatures: Record<string, string> = {
+export const HdlSignatures: Record<string, string> = {
   Add16: "Add16(a= , b= , out= );",
   ALU: "ALU(x= , y= , zx= , nx= , zy= , ny= , f= , no= , out= , zr= , ng= );",
   And: "And(a= , b= , out= );",

--- a/web/src/languages/hdl.ts
+++ b/web/src/languages/hdl.ts
@@ -116,7 +116,7 @@ export const HdlLanguage: monaco.languages.IMonarchLanguage = {
   },
 };
 
-const HdlSignatures = {
+const HdlSignatures: Record<string, string> = {
   Add16: "Add16(a= , b= , out= );",
   ALU: "ALU(x= , y= , zx= , nx= , zy= , ny= , f= , no= , out= , zr= , ng= );",
   And: "And(a= , b= , out= );",
@@ -155,6 +155,55 @@ const HdlSignatures = {
   Screen: "Screen(in= , load= , address= , out= );",
   Xor: "Xor(a= , b= , out= );",
 };
+
+const BuiltinChips = [...(HdlLanguage.chips as string[])];
+const BuiltinSignatures = { ...HdlSignatures };
+
+let customChipsAdded = false;
+
+export function registerCustomChip(name: string, signature: string) {
+  // Prevent re-registering the built-in chips or overriding them
+  if (BuiltinChips.includes(name)) {
+    return false;
+  }
+
+  let changed = false;
+  const chips = HdlLanguage.chips as string[];
+
+  if (!chips.includes(name)) {
+    chips.push(name);
+    changed = true;
+  }
+  if (HdlSignatures[name] !== signature) {
+    HdlSignatures[name] = signature;
+    changed = true;
+  }
+
+  if (changed) {
+    customChipsAdded = true;
+  }
+  return changed;
+}
+
+export function resetCustomChips() {
+  // No custom chips, just return
+  if (!customChipsAdded) {
+    return false;
+  }
+
+  HdlLanguage.chips = [...BuiltinChips];
+
+  // Reset Signatures
+  const currentKeys = Object.keys(HdlSignatures);
+  for (const key of currentKeys) {
+    delete HdlSignatures[key];
+  }
+  Object.assign(HdlSignatures, BuiltinSignatures);
+
+  customChipsAdded = false;
+
+  return true;
+}
 
 export const HdlSnippets = {
   provideCompletionItems: () => {

--- a/web/src/languages/loader.js
+++ b/web/src/languages/loader.js
@@ -22,7 +22,6 @@ let lock = false;
 export async function registerLanguages() {
   if (lock) return;
   lock = true;
-  lock = true;
   const { loader } = await import("@monaco-editor/react");
   const { languages } = await loader.init();
   for (const [id, language] of Object.entries(LANGUAGES)) {
@@ -34,4 +33,10 @@ export async function registerLanguages() {
     }
   }
   lock = false;
+}
+
+export async function reloadHdlLanguage() {
+  const { loader } = await import("@monaco-editor/react");
+  const { languages } = await loader.init();
+  languages.setMonarchTokensProvider("hdl", HdlLanguage);
 }

--- a/web/src/pages/ABOUT.md
+++ b/web/src/pages/ABOUT.md
@@ -2,7 +2,8 @@
 teaching of Nand to Tetris courses. It includes the following tools:
 
 **Hardware simulator:** Used to create chips. Features a built-in HDL editor and all the necessary
-services for simulating and testing chips. Relevant Nand to Tetris projects: 1, 2, 3, 5.
+services for simulating and testing chips. If the user enables PC storage, custom chips can be loaded 
+into other HDL files within the same project. Relevant Nand to Tetris projects: 1, 2, 3, 5.
 
 **CPU Emulator:** Emulates the Hack computer (CPU, RAM, ROM, Screen, Keyboard). Allows
 loading the computer with machine language code stored in a file, or entering machine language

--- a/web/src/pages/chip.tsx
+++ b/web/src/pages/chip.tsx
@@ -23,9 +23,12 @@ import { BaseContext } from "@nand2tetris/components/stores/base.context.js";
 import { hasBuiltinChip } from "@nand2tetris/simulator/chip/builtins/index.js";
 import { HDL } from "@nand2tetris/simulator/languages/hdl.js";
 import { Timer } from "@nand2tetris/simulator/timer.js";
+import { isErr, Ok } from "@davidsouther/jiffies/lib/esm/result.js";
 import { TestPanel } from "src/shell/test_panel";
 import { AppContext } from "../App.context";
 import { PageContext } from "../Page.context";
+import { registerCustomChip, resetCustomChips } from "../languages/hdl";
+import { reloadHdlLanguage } from "../languages/loader";
 import { Editor } from "../shell/editor";
 import { Accordian, Panel } from "../shell/panel";
 import { zip } from "../shell/zip";
@@ -55,6 +58,57 @@ export const Chip = () => {
       setTstDir(tstPath?.split("/").slice(0, -1).join("/"));
     }
   }, [tstPath]);
+
+  useEffect(() => {
+    if (!tstDir) return;
+    // Guard against race conditions when changing project
+    let active = true;
+
+    const scanAndRegister = async () => {
+      const files = await actions.getProjectFiles();
+      let changed = resetCustomChips();
+
+      for (const file of files) {
+        const chipNameFromPath = file.name.split("/").pop()?.replace(".hdl", "");
+
+        if (chipNameFromPath && hasBuiltinChip(chipNameFromPath)) {
+          continue;
+        }
+
+        const content = await file.content;
+        const parsed = HDL.parse(content);
+        if (isErr(parsed)) {
+          continue;
+        }
+
+        const hdl = Ok(parsed);
+        const chipName = hdl.name.value;
+
+        if (hasBuiltinChip(chipName)) {
+          continue;
+        }
+
+        const ins = hdl.ins.map(({ pin }: { pin: string }) => pin.toString());
+        const outs = hdl.outs.map(({ pin }: { pin: string }) => pin.toString());
+
+        const pins = [...ins, ...outs];
+        const signature = `${chipName}(${pins.map((p) => `${p}= `).join(", ")});`;
+
+        if (registerCustomChip(chipName, signature)) {
+          changed = true;
+        }
+      }
+
+      if (changed && active) {
+        reloadHdlLanguage();
+      }
+    };
+
+    scanAndRegister();
+    
+    // Cleanup function
+    return () => { active = false; };
+  }, [tstDir, actions]);
 
   useEffect(() => {
     setTool("chip");


### PR DESCRIPTION
This change allows the Hardware Simulator to scan the current project directory for custom .hdl files. It parses these files to extract chips, registering them as keywords in the currently opened project. Partially fixes #352. No GUI support yet for the user to create .hdl files.