### PR TITLE
Persist theme selection across reloads

### DIFF
--- a/e2e/tests/smoke/settings.spec.ts
+++ b/e2e/tests/smoke/settings.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+test(
+  "user picks Dark theme in Settings and the choice survives a reload",
+  { tag: ["@settings"] },
+  async ({ page }) => {
+    await page.goto("");
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+
+    await page.locator('li[data-tooltip="Settings"]').click();
+    const dialog = page.locator("dialog[open] article.settings-dialog");
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole("button", { name: "Dark" }).click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+
+    await dialog.locator("a.close").click();
+    await expect(dialog).toBeHidden();
+
+    await page.reload();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  },
+);

--- a/web/src/App.context.ts
+++ b/web/src/App.context.ts
@@ -1,10 +1,24 @@
 import { FileSystem } from "@davidsouther/jiffies/lib/esm/fs.js";
 import { useDialog } from "@nand2tetris/components/dialog.js";
-import { createContext, useCallback, useState } from "react";
+import { createContext, useCallback, useEffect, useState } from "react";
 import { useFilePicker } from "./shell/file_select";
 import { useTracking } from "./tracking";
 
 export type Theme = "light" | "dark" | "system";
+
+const THEME_KEY = "/theme";
+
+const isTheme = (v: unknown): v is Theme =>
+  v === "light" || v === "dark" || v === "system";
+
+function readStoredTheme(): Theme {
+  const stored = localStorage.getItem(THEME_KEY);
+  return isTheme(stored) ? stored : "system";
+}
+
+function writeStoredTheme(theme: Theme): void {
+  localStorage.setItem(THEME_KEY, theme);
+}
 
 export function useMonaco() {
   const canUseMonaco = true;
@@ -31,7 +45,11 @@ export function useMonaco() {
 }
 
 export function useAppContext(_fs: FileSystem = new FileSystem()) {
-  const [theme, setTheme] = useState<Theme>("system");
+  const [theme, setTheme] = useState<Theme>(readStoredTheme);
+
+  useEffect(() => {
+    writeStoredTheme(theme);
+  }, [theme]);
 
   return {
     monaco: useMonaco(),


### PR DESCRIPTION
Store the user's theme choice in localStorage["/theme"]and hydrate from it on mount. Adds the settings smoke test that exercises the dialog open, theme change, close, and reload-persists user story.