### PR TITLE
Bugfix Rollup

### DIFF
--- a/projects/src/project_02/06_alu.ts
+++ b/projects/src/project_02/06_alu.ts
@@ -464,6 +464,8 @@ export const basic_tst = `// This file is part of www.nand2tetris.org
 // Specifically: Tests the ALU logic that computes the 'out' output;
 // The 'zr' and 'ng' output bits are ignored.
 
+load ALU.hdl,
+compare-to ALU-basic.cmp,
 output-list x%B1.16.1 y%B1.16.1 zx nx zy ny f no out%B1.16.1;
 
 set x %B0000000000000000,

--- a/projects/src/samples/project_11/square/square_game.ts
+++ b/projects/src/samples/project_11/square/square_game.ts
@@ -467,7 +467,7 @@ export const parsed = {
                   rest: [
                     {
                       op: "=",
-                      term: { termType: "numericLiteral", value: 81 },
+                      term: { termType: "numericLiteral", value: 113 },
                     },
                   ],
                 },
@@ -476,14 +476,14 @@ export const parsed = {
                     statementType: "letStatement",
                     name: {
                       value: "exit",
-                      span: { start: 2070, end: 2074, line: 57 },
+                      span: { start: 2071, end: 2075, line: 57 },
                     },
                     value: {
                       nodeType: "expression",
                       term: { termType: "keywordLiteral", value: "true" },
                       rest: [],
                     },
-                    span: { start: 2066, end: 2082, line: 57 },
+                    span: { start: 2067, end: 2083, line: 57 },
                   },
                 ],
                 else: [],
@@ -495,12 +495,12 @@ export const parsed = {
                   term: {
                     termType: "variable",
                     name: "key",
-                    span: { start: 2111, end: 2114, line: 58 },
+                    span: { start: 2112, end: 2115, line: 58 },
                   },
                   rest: [
                     {
                       op: "=",
-                      term: { termType: "numericLiteral", value: 90 },
+                      term: { termType: "numericLiteral", value: 122 },
                     },
                   ],
                 },
@@ -511,10 +511,10 @@ export const parsed = {
                       termType: "subroutineCall",
                       name: {
                         value: "square.decSize",
-                        span: { start: 2127, end: 2141, line: 58 },
+                        span: { start: 2129, end: 2143, line: 58 },
                       },
                       parameters: [],
-                      span: { start: 2127, end: 2143, line: 58 },
+                      span: { start: 2129, end: 2145, line: 58 },
                     },
                   },
                 ],
@@ -527,12 +527,12 @@ export const parsed = {
                   term: {
                     termType: "variable",
                     name: "key",
-                    span: { start: 2169, end: 2172, line: 59 },
+                    span: { start: 2171, end: 2174, line: 59 },
                   },
                   rest: [
                     {
                       op: "=",
-                      term: { termType: "numericLiteral", value: 88 },
+                      term: { termType: "numericLiteral", value: 120 },
                     },
                   ],
                 },
@@ -543,10 +543,10 @@ export const parsed = {
                       termType: "subroutineCall",
                       name: {
                         value: "square.incSize",
-                        span: { start: 2185, end: 2199, line: 59 },
+                        span: { start: 2188, end: 2202, line: 59 },
                       },
                       parameters: [],
-                      span: { start: 2185, end: 2201, line: 59 },
+                      span: { start: 2188, end: 2204, line: 59 },
                     },
                   },
                 ],
@@ -559,12 +559,12 @@ export const parsed = {
                   term: {
                     termType: "variable",
                     name: "key",
-                    span: { start: 2227, end: 2230, line: 60 },
+                    span: { start: 2230, end: 2233, line: 60 },
                   },
                   rest: [
                     {
                       op: "=",
-                      term: { termType: "numericLiteral", value: 131 },
+                      term: { termType: "numericLiteral", value: 81 },
                     },
                   ],
                 },
@@ -572,15 +572,15 @@ export const parsed = {
                   {
                     statementType: "letStatement",
                     name: {
-                      value: "direction",
-                      span: { start: 2244, end: 2253, line: 60 },
+                      value: "exit",
+                      span: { start: 2247, end: 2251, line: 60 },
                     },
                     value: {
                       nodeType: "expression",
-                      term: { termType: "numericLiteral", value: 1 },
+                      term: { termType: "keywordLiteral", value: "true" },
                       rest: [],
                     },
-                    span: { start: 2240, end: 2258, line: 60 },
+                    span: { start: 2243, end: 2259, line: 60 },
                   },
                 ],
                 else: [],
@@ -597,23 +597,22 @@ export const parsed = {
                   rest: [
                     {
                       op: "=",
-                      term: { termType: "numericLiteral", value: 133 },
+                      term: { termType: "numericLiteral", value: 90 },
                     },
                   ],
                 },
                 body: [
                   {
-                    statementType: "letStatement",
-                    name: {
-                      value: "direction",
-                      span: { start: 2305, end: 2314, line: 61 },
+                    statementType: "doStatement",
+                    call: {
+                      termType: "subroutineCall",
+                      name: {
+                        value: "square.decSize",
+                        span: { start: 2304, end: 2318, line: 61 },
+                      },
+                      parameters: [],
+                      span: { start: 2304, end: 2320, line: 61 },
                     },
-                    value: {
-                      nodeType: "expression",
-                      term: { termType: "numericLiteral", value: 2 },
-                      rest: [],
-                    },
-                    span: { start: 2301, end: 2319, line: 61 },
                   },
                 ],
                 else: [],
@@ -625,7 +624,105 @@ export const parsed = {
                   term: {
                     termType: "variable",
                     name: "key",
-                    span: { start: 2351, end: 2354, line: 62 },
+                    span: { start: 2346, end: 2349, line: 62 },
+                  },
+                  rest: [
+                    {
+                      op: "=",
+                      term: { termType: "numericLiteral", value: 88 },
+                    },
+                  ],
+                },
+                body: [
+                  {
+                    statementType: "doStatement",
+                    call: {
+                      termType: "subroutineCall",
+                      name: {
+                        value: "square.incSize",
+                        span: { start: 2362, end: 2376, line: 62 },
+                      },
+                      parameters: [],
+                      span: { start: 2362, end: 2378, line: 62 },
+                    },
+                  },
+                ],
+                else: [],
+              },
+              {
+                statementType: "ifStatement",
+                condition: {
+                  nodeType: "expression",
+                  term: {
+                    termType: "variable",
+                    name: "key",
+                    span: { start: 2404, end: 2407, line: 63 },
+                  },
+                  rest: [
+                    {
+                      op: "=",
+                      term: { termType: "numericLiteral", value: 131 },
+                    },
+                  ],
+                },
+                body: [
+                  {
+                    statementType: "letStatement",
+                    name: {
+                      value: "direction",
+                      span: { start: 2421, end: 2430, line: 63 },
+                    },
+                    value: {
+                      nodeType: "expression",
+                      term: { termType: "numericLiteral", value: 1 },
+                      rest: [],
+                    },
+                    span: { start: 2417, end: 2435, line: 63 },
+                  },
+                ],
+                else: [],
+              },
+              {
+                statementType: "ifStatement",
+                condition: {
+                  nodeType: "expression",
+                  term: {
+                    termType: "variable",
+                    name: "key",
+                    span: { start: 2465, end: 2468, line: 64 },
+                  },
+                  rest: [
+                    {
+                      op: "=",
+                      term: { termType: "numericLiteral", value: 133 },
+                    },
+                  ],
+                },
+                body: [
+                  {
+                    statementType: "letStatement",
+                    name: {
+                      value: "direction",
+                      span: { start: 2482, end: 2491, line: 64 },
+                    },
+                    value: {
+                      nodeType: "expression",
+                      term: { termType: "numericLiteral", value: 2 },
+                      rest: [],
+                    },
+                    span: { start: 2478, end: 2496, line: 64 },
+                  },
+                ],
+                else: [],
+              },
+              {
+                statementType: "ifStatement",
+                condition: {
+                  nodeType: "expression",
+                  term: {
+                    termType: "variable",
+                    name: "key",
+                    span: { start: 2528, end: 2531, line: 65 },
                   },
                   rest: [
                     {
@@ -639,14 +736,14 @@ export const parsed = {
                     statementType: "letStatement",
                     name: {
                       value: "direction",
-                      span: { start: 2368, end: 2377, line: 62 },
+                      span: { start: 2545, end: 2554, line: 65 },
                     },
                     value: {
                       nodeType: "expression",
                       term: { termType: "numericLiteral", value: 3 },
                       rest: [],
                     },
-                    span: { start: 2364, end: 2382, line: 62 },
+                    span: { start: 2541, end: 2559, line: 65 },
                   },
                 ],
                 else: [],
@@ -658,7 +755,7 @@ export const parsed = {
                   term: {
                     termType: "variable",
                     name: "key",
-                    span: { start: 2414, end: 2417, line: 63 },
+                    span: { start: 2591, end: 2594, line: 66 },
                   },
                   rest: [
                     {
@@ -672,14 +769,14 @@ export const parsed = {
                     statementType: "letStatement",
                     name: {
                       value: "direction",
-                      span: { start: 2431, end: 2440, line: 63 },
+                      span: { start: 2608, end: 2617, line: 66 },
                     },
                     value: {
                       nodeType: "expression",
                       term: { termType: "numericLiteral", value: 4 },
                       rest: [],
                     },
-                    span: { start: 2427, end: 2445, line: 63 },
+                    span: { start: 2604, end: 2622, line: 66 },
                   },
                 ],
                 else: [],
@@ -698,7 +795,7 @@ export const parsed = {
                         term: {
                           termType: "variable",
                           name: "key",
-                          span: { start: 2529, end: 2532, line: 66 },
+                          span: { start: 2706, end: 2709, line: 69 },
                         },
                         rest: [
                           {
@@ -716,7 +813,7 @@ export const parsed = {
                     statementType: "letStatement",
                     name: {
                       value: "key",
-                      span: { start: 2557, end: 2560, line: 67 },
+                      span: { start: 2734, end: 2737, line: 70 },
                     },
                     value: {
                       nodeType: "expression",
@@ -724,14 +821,14 @@ export const parsed = {
                         termType: "subroutineCall",
                         name: {
                           value: "Keyboard.keyPressed",
-                          span: { start: 2563, end: 2582, line: 67 },
+                          span: { start: 2740, end: 2759, line: 70 },
                         },
                         parameters: [],
-                        span: { start: 2563, end: 2584, line: 67 },
+                        span: { start: 2740, end: 2761, line: 70 },
                       },
                       rest: [],
                     },
-                    span: { start: 2553, end: 2585, line: 67 },
+                    span: { start: 2730, end: 2762, line: 70 },
                   },
                   {
                     statementType: "doStatement",
@@ -739,10 +836,10 @@ export const parsed = {
                       termType: "subroutineCall",
                       name: {
                         value: "moveSquare",
-                        span: { start: 2601, end: 2611, line: 68 },
+                        span: { start: 2778, end: 2788, line: 71 },
                       },
                       parameters: [],
-                      span: { start: 2601, end: 2613, line: 68 },
+                      span: { start: 2778, end: 2790, line: 71 },
                     },
                   },
                 ],
@@ -751,7 +848,7 @@ export const parsed = {
           },
           {
             statementType: "returnStatement",
-            span: { start: 2647, end: 2654, line: 71 },
+            span: { start: 2824, end: 2831, line: 74 },
           },
         ],
       },
@@ -859,7 +956,7 @@ label SquareGame_10
     goto SquareGame_10
 label SquareGame_11
     push local 0
-    push constant 81
+    push constant 113
     eq
     not
     if-goto SquareGame_13
@@ -870,7 +967,7 @@ label SquareGame_11
 label SquareGame_13
 label SquareGame_12
     push local 0
-    push constant 90
+    push constant 122
     eq
     not
     if-goto SquareGame_15
@@ -881,7 +978,7 @@ label SquareGame_12
 label SquareGame_15
 label SquareGame_14
     push local 0
-    push constant 88
+    push constant 120
     eq
     not
     if-goto SquareGame_17
@@ -892,59 +989,92 @@ label SquareGame_14
 label SquareGame_17
 label SquareGame_16
     push local 0
-    push constant 131
+    push constant 81
     eq
     not
     if-goto SquareGame_19
     push constant 1
-    pop this 1
+    neg
+    pop local 1
     goto SquareGame_18
 label SquareGame_19
 label SquareGame_18
     push local 0
-    push constant 133
+    push constant 90
     eq
     not
     if-goto SquareGame_21
-    push constant 2
-    pop this 1
+    push this 0
+    call Square.decSize 1
+    pop temp 0
     goto SquareGame_20
 label SquareGame_21
 label SquareGame_20
     push local 0
-    push constant 130
+    push constant 88
     eq
     not
     if-goto SquareGame_23
-    push constant 3
-    pop this 1
+    push this 0
+    call Square.incSize 1
+    pop temp 0
     goto SquareGame_22
 label SquareGame_23
 label SquareGame_22
     push local 0
-    push constant 132
+    push constant 131
     eq
     not
     if-goto SquareGame_25
-    push constant 4
+    push constant 1
     pop this 1
     goto SquareGame_24
 label SquareGame_25
 label SquareGame_24
+    push local 0
+    push constant 133
+    eq
+    not
+    if-goto SquareGame_27
+    push constant 2
+    pop this 1
+    goto SquareGame_26
+label SquareGame_27
 label SquareGame_26
+    push local 0
+    push constant 130
+    eq
+    not
+    if-goto SquareGame_29
+    push constant 3
+    pop this 1
+    goto SquareGame_28
+label SquareGame_29
+label SquareGame_28
+    push local 0
+    push constant 132
+    eq
+    not
+    if-goto SquareGame_31
+    push constant 4
+    pop this 1
+    goto SquareGame_30
+label SquareGame_31
+label SquareGame_30
+label SquareGame_32
     push local 0
     push constant 0
     eq
     not
     not
-    if-goto SquareGame_27
+    if-goto SquareGame_33
     call Keyboard.keyPressed 0
     pop local 0
     push pointer 0
     call SquareGame.moveSquare 1
     pop temp 0
-    goto SquareGame_26
-label SquareGame_27
+    goto SquareGame_32
+label SquareGame_33
     goto SquareGame_8
 label SquareGame_9
     push constant 0

--- a/projects/src/samples/project_11/square/square_game.ts
+++ b/projects/src/samples/project_11/square/square_game.ts
@@ -9,8 +9,8 @@ export const jack = `// This file is part of www.nand2tetris.org
  * When the game starts, a square of 30 by 30 pixels is shown at the
  * top-left corner of the screen. The user controls the square as follows.
  * The 4 arrow keys are used to move the square up, down, left, and right.
- * The 'z' and 'x' keys are used, respectively, to decrement and increment
- * the square's size. The 'q' key is used to quit the game.
+ * The 'Z' and 'X' keys are used, respectively, to decrement and increment
+ * the square's size. The 'Q' key is used to quit the game.
  */
 class SquareGame {
    field Square square; // the square of this game
@@ -54,9 +54,12 @@ class SquareGame {
             let key = Keyboard.keyPressed();
             do moveSquare();
          }
-         if (key = 81)  { let exit = true; }     // q key
-         if (key = 90)  { do square.decSize(); } // z key
-         if (key = 88)  { do square.incSize(); } // x key
+         if (key = 113)  { let exit = true; }     // q key
+         if (key = 122)  { do square.decSize(); } // z key
+         if (key = 120)  { do square.incSize(); } // x key
+         if (key = 81)  { let exit = true; }     // Q key
+         if (key = 90)  { do square.decSize(); } // Z key
+         if (key = 88)  { do square.incSize(); } // X key
          if (key = 131) { let direction = 1; }   // up arrow
          if (key = 133) { let direction = 2; }   // down arrow
          if (key = 130) { let direction = 3; }   // left arrow

--- a/simulator/src/languages/jack.test.ts
+++ b/simulator/src/languages/jack.test.ts
@@ -4,8 +4,8 @@ import { describe, expect, it } from "vitest";
 import { JACK } from "./jack.js";
 
 describe("jack language", () => {
-  describe.each(Object.keys(Programs))("%s", (program) => {
-    it.each(Object.keys(Programs[program]))("%s", (filename) => {
+  describe.each(Object.keys(Programs))("Program %s", (program) => {
+    it.each(Object.keys(Programs[program]))("File %s", (filename) => {
       const parsed = JACK.parse(Programs[program][filename].jack);
       expect(parsed).toBeOk();
       expect(unwrap(parsed)).toEqual(Programs[program][filename].parsed);

--- a/simulator/src/vm/vm.test.ts
+++ b/simulator/src/vm/vm.test.ts
@@ -1,4 +1,4 @@
-import { unwrap } from "@davidsouther/jiffies/lib/esm/result.js";
+import { Err, isErr, unwrap } from "@davidsouther/jiffies/lib/esm/result.js";
 import { vm as SIMPLE_FUNCTION } from "@nand2tetris/projects/project_08/20_simple_function.js";
 import { FIBONACCI } from "@nand2tetris/projects/samples/vm/fibonnaci.js";
 import {
@@ -400,4 +400,10 @@ describe("debug frame views", () => {
 
     expect(vm.vmStack().length).toBe(1);
   });
+});
+
+test("buildFromFiles with no files returns a CompilationError", () => {
+  const result = Vm.buildFromFiles([]);
+  if (!isErr(result)) throw new Error("expected Err result");
+  expect(Err(result).message).toMatch(/no\s+\.vm/i);
 });

--- a/simulator/src/vm/vm.test.ts
+++ b/simulator/src/vm/vm.test.ts
@@ -407,3 +407,89 @@ test("buildFromFiles with no files returns a CompilationError", () => {
   if (!isErr(result)) throw new Error("expected Err result");
   expect(Err(result).message).toMatch(/no\s+\.vm/i);
 });
+
+describe("Array.new / Array.dispose bridge to user Memory", () => {
+  test("Array.new dispatches to user Memory.alloc when supplied", () => {
+    const program = `
+function Memory.alloc 0
+push constant 4660
+return
+
+function Main.main 0
+push constant 7
+call Array.new 1
+return
+`;
+    const { instructions } = unwrap(VM.parse(program));
+    const vm = unwrap(Vm.build(instructions));
+
+    const arrayNew = vm.functionMap["Array.new"];
+    expect(arrayNew).toBeDefined();
+    expect(
+      arrayNew.operations.some(
+        (op) => op.op === "call" && op.name === "Memory.alloc",
+      ),
+    ).toBe(true);
+  });
+
+  test("Array.dispose dispatches to user Memory.deAlloc when supplied", () => {
+    const program = `
+function Memory.deAlloc 0
+push constant 0
+return
+
+function Main.main 0
+push constant 0
+return
+`;
+    const { instructions } = unwrap(VM.parse(program));
+    const vm = unwrap(Vm.build(instructions));
+
+    const arrayDispose = vm.functionMap["Array.dispose"];
+    expect(arrayDispose).toBeDefined();
+    expect(
+      arrayDispose.operations.some(
+        (op) => op.op === "call" && op.name === "Memory.deAlloc",
+      ),
+    ).toBe(true);
+  });
+
+  test("bridge is not injected when user supplies their own Array.new", () => {
+    const program = `
+function Memory.alloc 0
+push constant 4660
+return
+
+function Array.new 0
+push constant 999
+return
+
+function Main.main 0
+push constant 0
+return
+`;
+    const { instructions } = unwrap(VM.parse(program));
+    const vm = unwrap(Vm.build(instructions));
+
+    const arrayNew = vm.functionMap["Array.new"];
+    expect(
+      arrayNew.operations.some(
+        (op) =>
+          op.op === "push" && op.segment === "constant" && op.offset === 999,
+      ),
+    ).toBe(true);
+  });
+
+  test("bridge is not injected when user does not supply Memory.alloc", () => {
+    const program = `
+function Main.main 0
+push constant 0
+return
+`;
+    const { instructions } = unwrap(VM.parse(program));
+    const vm = unwrap(Vm.build(instructions));
+
+    expect(vm.functionMap["Array.new"]).toBeUndefined();
+    expect(vm.functionMap["Array.dispose"]).toBeUndefined();
+  });
+});

--- a/simulator/src/vm/vm.ts
+++ b/simulator/src/vm/vm.ts
@@ -86,6 +86,34 @@ export const SYS_INIT: VmFunction = {
   ],
 };
 
+const ARRAY_NEW_BRIDGE: VmFunction = {
+  name: "Array.new",
+  labels: {},
+  nVars: 0,
+  opBase: 0,
+  operations: [
+    { op: "function", name: "Array.new", nVars: 0 },
+    { op: "push", segment: "argument", offset: 0 },
+    { op: "call", name: "Memory.alloc", nArgs: 1 },
+    { op: "return" },
+  ],
+};
+
+const ARRAY_DISPOSE_BRIDGE: VmFunction = {
+  name: "Array.dispose",
+  labels: {},
+  nVars: 0,
+  opBase: 0,
+  operations: [
+    { op: "function", name: "Array.dispose", nVars: 0 },
+    { op: "push", segment: "argument", offset: 0 },
+    { op: "call", name: "Memory.deAlloc", nArgs: 1 },
+    { op: "pop", segment: "temp", offset: 0 },
+    { op: "push", segment: "constant", offset: 0 },
+    { op: "return" },
+  ],
+};
+
 export interface ParsedVmFile {
   name: string;
   instructions: VmInstruction[];
@@ -537,6 +565,19 @@ export class Vm {
       this.functionMap[SYS_INIT.name] = SYS_INIT;
       this.addedSysInit = true;
       // TODO should this be an error from the compiler/OS?
+    }
+
+    if (
+      this.functionMap["Memory.alloc"] &&
+      !this.functionMap[ARRAY_NEW_BRIDGE.name]
+    ) {
+      this.functionMap[ARRAY_NEW_BRIDGE.name] = ARRAY_NEW_BRIDGE;
+    }
+    if (
+      this.functionMap["Memory.deAlloc"] &&
+      !this.functionMap[ARRAY_DISPOSE_BRIDGE.name]
+    ) {
+      this.functionMap[ARRAY_DISPOSE_BRIDGE.name] = ARRAY_DISPOSE_BRIDGE;
     }
 
     if (this.functionMap[SYS_INIT.name]) {

--- a/simulator/src/vm/vm.ts
+++ b/simulator/src/vm/vm.ts
@@ -279,13 +279,18 @@ export class Vm {
   }
 
   static buildFromFiles(files: ParsedVmFile[]): Result<Vm, CompilationError> {
+    if (files.length === 0) {
+      return Err(
+        createError("No .vm files to load. Compile your Jack files first."),
+      );
+    }
     let result = this.validateFiles(files);
     if (isErr(result)) {
       return result;
     }
     const instructions = files
       .map((file) => file.instructions)
-      .reduce((list1, list2) => list1.concat(list2));
+      .reduce((list1, list2) => list1.concat(list2), [] as VmInstruction[]);
     result = this.validateFunctions(instructions);
     if (isErr(result)) {
       return result;


### PR DESCRIPTION
## Summary

A rollup of four independent end-user defects, each with its own root cause. Bundled together because they were burned down in one sitting on the same branch.

## Fixes

### `ALU-basic.tst` was missing its load directive — closes #549

`projects/02/ALU-basic.tst` shipped without `load ALU.hdl,` and `compare-to ALU-basic.cmp,`. The Hardware Simulator rejected it with "A test script must have a load command", and the editor was read-only so students could not patch around it. Three reporters filed the same defect (#549, #573, #630).

### Project 11 Square sample inline keys did not match keyCodes — closes #611

The Project 11 `Square` sample's docstring and inline comments referenced lowercase `q`/`z`/`x`, but the keyCode constants 81/90/88 are uppercase Q/Z/X. The sample now accepts both lowercase ASCII (113/122/120) and uppercase ASCII (81/90/88), and the comments name the keys correctly.

### `Vm.buildFromFiles` crashed on a directory with no `.vm` files — closes #616

Loading a `.tst` whose `load,` directive pointed at a directory containing no compiled `.vm` files caused an unseeded `Array.reduce` to throw `"Reduce of empty array with no initial value"`, which blanked the VM panel without surfacing a user-facing error. Project 12 students hit this whenever they opened a `.tst` before compiling their Jack sources. `Vm.buildFromFiles` now returns a `CompilationError` with a clear message in that case, and the reduce is seeded defensively. Covered by a new unit test in `simulator/src/vm/vm.test.ts`.

### `Array.new` and `Array.dispose` bypassed the student's `Memory.alloc`/`deAlloc` — closes #618

The `VM_BUILTINS` implementations of `Array.new` and `Array.dispose` called the TypeScript `MemoryLib` directly, so `MemoryTest/Main.jack` passed even when the student's `Memory.jack` `alloc`/`deAlloc` was broken (e.g. `do Sys.error(1);` in their `alloc`). Project 12 students could not actually verify their `Memory` implementation against `MemoryTest`.

The fix injects synthetic `Array.new` and `Array.dispose` `VmFunction`s into `functionMap` during `bootstrap()` — but only when the user supplied `Memory.alloc`/`Memory.deAlloc` and did not supply their own `Array.new`/`Array.dispose`. The dispatch loop already prefers `functionMap` entries over `VM_BUILTINS`, so the synthetic bridges win and route allocation through the student's code. The same synthetic-function precedent is used for `SYS_INIT`. Four new unit tests cover the bridge cases.

**Behaviour matrix:**

| `Memory.alloc` supplied | `Array.new` supplied | Behaviour                                                |
|-------------------------|----------------------|----------------------------------------------------------|
| no                      | no                   | builtin `Array.new` runs (unchanged)                     |
| yes                     | no                   | synthetic bridge calls user's `Memory.alloc` (fixed)     |
| yes                     | yes                  | user's `Array.new` runs (unchanged)                      |
