### PR TITLE
Bugfix Rollup 2

### DIFF
--- a/components/src/react.test.tsx
+++ b/components/src/react.test.tsx
@@ -1,0 +1,33 @@
+import { act, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { useStateInitializer } from "./react.js";
+
+function Probe({ init }: { init: string }) {
+  const [value] = useStateInitializer(init);
+  return <div data-testid="probe">{`init=${init}|value=${value}`}</div>;
+}
+
+function Harness() {
+  const [init, setInit] = useState("a");
+  return (
+    <>
+      <Probe init={init} />
+      <button type="button" onClick={() => setInit("b")}>
+        change
+      </button>
+    </>
+  );
+}
+
+describe("useStateInitializer", () => {
+  it("returns the new value on the same render that init changes", () => {
+    render(<Harness />);
+    expect(screen.getByTestId("probe").textContent).toBe("init=a|value=a");
+
+    act(() => {
+      screen.getByText("change").click();
+    });
+
+    expect(screen.getByTestId("probe").textContent).toBe("init=b|value=b");
+  });
+});

--- a/components/src/react.ts
+++ b/components/src/react.ts
@@ -1,5 +1,5 @@
 import { produce } from "immer";
-import { Dispatch, useEffect, useReducer, useState } from "react";
+import { Dispatch, useReducer, useState } from "react";
 
 export function useImmerReducer<
   T,
@@ -24,8 +24,13 @@ export function useImmerReducer<
 
 export function useStateInitializer<T>(init: T): [T, Dispatch<T>] {
   const [state, setState] = useState<T>(init);
-  useEffect(() => {
+  const [prevInit, setPrevInit] = useState<T>(init);
+  if (init !== prevInit) {
+    // Sync derived state during render so consumers (notably the Monaco editor
+    // path/value pair) never see a render where init has changed but state
+    // still holds the previous value.
+    setPrevInit(init);
     setState(init);
-  }, [init]);
+  }
   return [state, setState];
 }

--- a/components/src/stores/chip.store.test.ts
+++ b/components/src/stores/chip.store.test.ts
@@ -60,6 +60,31 @@ describe("ChipStore", () => {
       expect(store.state.files.cmp).toBe("");
       expect(store.state.files.out).toBe("");
     });
+
+    it("keeps the auto-loaded chip selected after initialize", async () => {
+      const store = testChipStore({
+        "projects/01/Not.hdl": not.hdl,
+        "projects/01/Not.tst": not.tst,
+        "projects/01/Not.cmp": not.cmp,
+      });
+
+      await store.actions.initialize();
+
+      expect(store.state.controls.project).toBe("01");
+      expect(store.state.controls.chipName).not.toBe("");
+      expect(store.state.controls.chips.length).toBeGreaterThan(0);
+    });
+
+    it("clears chip name when no projects are present", async () => {
+      const store = testChipStore({
+        "projects/README.md": "no chips here",
+      });
+
+      await store.actions.initialize();
+
+      expect(store.state.controls.chipName).toBe("");
+      expect(store.state.controls.chips).toEqual([]);
+    });
   });
 
   describe("behavior", () => {

--- a/components/src/stores/chip.store.ts
+++ b/components/src/stores/chip.store.ts
@@ -316,9 +316,8 @@ export function makeChipStore(
         await actions.setProject(sortedNames[0]);
       } else {
         dispatch.current({ action: "setChips", payload: [] });
+        dispatch.current({ action: "clearChip" });
       }
-
-      dispatch.current({ action: "clearChip" });
     },
 
     reset() {
@@ -344,7 +343,7 @@ export function makeChipStore(
       dispatch.current({ action: "setChips", payload });
 
       if (chips.length > 0) {
-        this.loadChip(`${prefix}/${project}/${chips[0]}.hdl`, true);
+        await this.loadChip(`${prefix}/${project}/${chips[0]}.hdl`, true);
       }
     },
 

--- a/simulator/src/timer.test.ts
+++ b/simulator/src/timer.test.ts
@@ -1,0 +1,52 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { Timer } from "./timer.js";
+
+const globals = globalThis as { requestAnimationFrame?: (cb: () => void) => 0 };
+let originalRAF: typeof globals.requestAnimationFrame;
+beforeAll(() => {
+  originalRAF = globals.requestAnimationFrame;
+  globals.requestAnimationFrame = () => 0;
+});
+afterAll(() => {
+  globals.requestAnimationFrame = originalRAF;
+});
+
+class TestTimer extends Timer {
+  publicStepsActual(): number {
+    return (this as unknown as { _steps_actual: number })._steps_actual;
+  }
+  setStepsActual(v: number) {
+    (this as unknown as { _steps_actual: number })._steps_actual = v;
+  }
+  override async tick(): Promise<boolean> {
+    return false;
+  }
+  override reset(): void {
+    return;
+  }
+  override toggle(): void {
+    return;
+  }
+  override finishFrame(): void {
+    return;
+  }
+}
+
+describe("Timer", () => {
+  test("setting steps resets the dynamic step budget", () => {
+    const timer = new TestTimer();
+    timer.steps = 100;
+    timer.setStepsActual(1);
+    timer.steps = 100;
+    expect(timer.publicStepsActual()).toBe(100);
+  });
+
+  test("start resets the dynamic step budget", () => {
+    const timer = new TestTimer();
+    timer.steps = 1000;
+    timer.setStepsActual(1);
+    timer.start();
+    expect(timer.publicStepsActual()).toBe(1000);
+    timer.stop();
+  });
+});

--- a/simulator/src/timer.ts
+++ b/simulator/src/timer.ts
@@ -91,6 +91,7 @@ export abstract class Timer {
 
   start() {
     this.stepsTaken = 0;
+    this._steps_actual = this._steps;
     this.#running = true;
     this.#lastUpdate = Date.now() - this.speed;
     this.#run();

--- a/simulator/src/vm/os/memory.test.ts
+++ b/simulator/src/vm/os/memory.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "vitest";
+import { VmMemory } from "../memory.js";
+import { MemoryLib } from "./memory.js";
+import { OS } from "./os.js";
+
+const HEAP_BASE = 2048;
+const HEAP_SIZE = 14334;
+
+function makeLib() {
+  const memory = new VmMemory();
+  const os = new OS(memory);
+  return { memory, lib: os.memory };
+}
+
+function freeList(memory: VmMemory, lib: MemoryLib): number[] {
+  const seen: number[] = [];
+  let p = (lib as unknown as { freeListPtr: number }).freeListPtr;
+  while (p !== 0) {
+    if (seen.includes(p)) {
+      throw new Error(`free list cycle at ${p}: ${seen.join(" -> ")}`);
+    }
+    seen.push(p);
+    p = memory.get(p);
+  }
+  return seen;
+}
+
+describe("MemoryLib", () => {
+  test("initializes a single heap-sized free block", () => {
+    const { memory, lib } = makeLib();
+    expect(memory.get(HEAP_BASE)).toBe(0);
+    expect(memory.get(HEAP_BASE + 1)).toBe(HEAP_SIZE);
+    expect(freeList(memory, lib)).toEqual([HEAP_BASE]);
+  });
+
+  test("alloc returns the user-data pointer and records the size header", () => {
+    const { memory, lib } = makeLib();
+    const p = lib.alloc(10);
+    expect(p).toBe(HEAP_BASE + 2);
+    expect(memory.get(p - 1)).toBe(10);
+  });
+
+  test("alloc/deAlloc round trip leaves the heap usable", () => {
+    const { lib } = makeLib();
+    const p = lib.alloc(10);
+    lib.deAlloc(p);
+    const q = lib.alloc(10);
+    expect(typeof q).toBe("number");
+    expect(q).toBeGreaterThan(0);
+  });
+
+  test("repeated alloc/write/deAlloc with non-zero user data does not hang", () => {
+    const { memory, lib } = makeLib();
+    for (let iter = 0; iter < 50; iter++) {
+      const piece = lib.alloc(3);
+      const tiles = lib.alloc(10);
+      for (let i = 0; i < 10; i++) {
+        memory.set(tiles + i, i % 2 === 0 ? -1 : 12345);
+      }
+      lib.deAlloc(tiles);
+      lib.deAlloc(piece);
+      // freeList walk throws on cycle; repeated calls verify no corruption.
+      freeList(memory, lib);
+    }
+  });
+
+  test("alloc that splits a non-head free block keeps the free list well formed", () => {
+    const { memory, lib } = makeLib();
+    // Force two free blocks where the head is too small for a later request.
+    const a = lib.alloc(10);
+    const b = lib.alloc(10);
+    lib.deAlloc(a);
+    // Shrink the head so the next alloc must walk past it.
+    const headPtr = (lib as unknown as { freeListPtr: number }).freeListPtr;
+    memory.set(headPtr + 1, 5);
+    const c = lib.alloc(8);
+    expect(c).toBeGreaterThan(0);
+    // Returned pointer must not still be linked into the free list.
+    const blockPtr = c - 2;
+    const list = freeList(memory, lib);
+    expect(list).not.toContain(blockPtr);
+    void b;
+  });
+
+  test("alloc that splits a non-head block does not lose the remainder", () => {
+    const { memory, lib } = makeLib();
+    const a = lib.alloc(10);
+    const b = lib.alloc(10);
+    lib.deAlloc(a);
+    const headPtr = (lib as unknown as { freeListPtr: number }).freeListPtr;
+    memory.set(headPtr + 1, 5);
+    const before = freeList(memory, lib).length;
+    lib.alloc(8);
+    const after = freeList(memory, lib).length;
+    // One free block is consumed and one remainder added: list length unchanged.
+    expect(after).toBe(before);
+    void b;
+  });
+});

--- a/simulator/src/vm/os/memory.ts
+++ b/simulator/src/vm/os/memory.ts
@@ -24,28 +24,31 @@ export class MemoryLib {
       return 0;
     }
 
+    let prevPtr = 0;
     let blockPtr = this.freeListPtr;
-    do {
+    while (blockPtr !== 0) {
       const nextFreeList = this.memory.get(blockPtr);
       const blockSize = this.memory.get(blockPtr + 1);
       if (blockSize >= size + 2) {
-        // We can fit this required size and overhead in this block.
         this.memory.set(blockPtr + 1, size);
 
         const newBlockPtr = blockPtr + 2 + size;
         const newBlockSize = blockSize - size - 2;
         this.memory.set(newBlockPtr, nextFreeList);
         this.memory.set(newBlockPtr + 1, newBlockSize);
-        if (this.freeListPtr === blockPtr) {
-          // Move freelist pointer to the new block.
+
+        // Unlink the allocated block by pointing the predecessor (or the
+        // free list head) at the new remainder block.
+        if (prevPtr === 0) {
           this.freeListPtr = newBlockPtr;
+        } else {
+          this.memory.set(prevPtr, newBlockPtr);
         }
         return blockPtr + 2;
-      } else {
-        // We can't fit this required size and overhead in this block.
-        blockPtr = nextFreeList;
       }
-    } while (blockPtr !== 0);
+      prevPtr = blockPtr;
+      blockPtr = nextFreeList;
+    }
 
     this.os.sys.error(ERRNO.HEAP_OVERFLOW);
     return 0;
@@ -53,17 +56,7 @@ export class MemoryLib {
 
   deAlloc(address: number) {
     const deallocBlockPtr = address - 2;
-    // This will be the last block in the free list.
-    this.memory.set(deallocBlockPtr, 0);
-
-    let blockPtr = this.freeListPtr;
-    do {
-      const nextBlockPtr = this.memory.get(blockPtr);
-      if (nextBlockPtr === 0) {
-        this.memory.set(blockPtr, deallocBlockPtr);
-        return;
-      }
-      blockPtr = nextBlockPtr;
-    } while (blockPtr !== 0);
+    this.memory.set(deallocBlockPtr, this.freeListPtr);
+    this.freeListPtr = deallocBlockPtr;
   }
 }

--- a/simulator/src/vm/vm.test.ts
+++ b/simulator/src/vm/vm.test.ts
@@ -400,6 +400,18 @@ describe("debug frame views", () => {
 
     expect(vm.vmStack().length).toBe(1);
   });
+
+  test("entry frame `that` reflects memory at THAT, not the THAT pointer", () => {
+    const { instructions } = unwrap(VM.parse(FIBONACCI));
+    const vm = unwrap(Vm.build(instructions));
+    // Set the THAT pointer and the memory it points to so the two are easy
+    // to distinguish.
+    vm.memory.set(4, 12345);
+    vm.memory.set(12345, 7777);
+
+    const top = vm.vmStack()[0];
+    expect(top.that.values).toEqual([7777]);
+  });
 });
 
 test("buildFromFiles with no files returns a CompilationError", () => {

--- a/simulator/src/vm/vm.test.ts
+++ b/simulator/src/vm/vm.test.ts
@@ -505,3 +505,74 @@ return
     expect(vm.functionMap["Array.dispose"]).toBeUndefined();
   });
 });
+
+describe("Output.printString bridge to user String", () => {
+  test("Output.printString dispatches to user String.charAt when supplied", () => {
+    const program = `
+function String.charAt 0
+push constant 0
+return
+
+function String.length 0
+push constant 0
+return
+
+function Main.main 0
+push constant 0
+return
+`;
+    const { instructions } = unwrap(VM.parse(program));
+    const vm = unwrap(Vm.build(instructions));
+
+    const printString = vm.functionMap["Output.printString"];
+    expect(printString).toBeDefined();
+    expect(
+      printString.operations.some(
+        (op) => op.op === "call" && op.name === "String.charAt",
+      ),
+    ).toBe(true);
+    expect(
+      printString.operations.some(
+        (op) => op.op === "call" && op.name === "String.length",
+      ),
+    ).toBe(true);
+  });
+
+  test("bridge is not injected when user supplies their own Output.printString", () => {
+    const program = `
+function String.charAt 0
+push constant 0
+return
+
+function Output.printString 0
+push constant 999
+return
+
+function Main.main 0
+push constant 0
+return
+`;
+    const { instructions } = unwrap(VM.parse(program));
+    const vm = unwrap(Vm.build(instructions));
+
+    const printString = vm.functionMap["Output.printString"];
+    expect(
+      printString.operations.some(
+        (op) =>
+          op.op === "push" && op.segment === "constant" && op.offset === 999,
+      ),
+    ).toBe(true);
+  });
+
+  test("bridge is not injected when user does not supply String.charAt", () => {
+    const program = `
+function Main.main 0
+push constant 0
+return
+`;
+    const { instructions } = unwrap(VM.parse(program));
+    const vm = unwrap(Vm.build(instructions));
+
+    expect(vm.functionMap["Output.printString"]).toBeUndefined();
+  });
+});

--- a/simulator/src/vm/vm.ts
+++ b/simulator/src/vm/vm.ts
@@ -114,6 +114,42 @@ const ARRAY_DISPOSE_BRIDGE: VmFunction = {
   ],
 };
 
+// Walks a string by calling String.length / String.charAt so a
+// user-supplied String.jack (with a custom internal layout) is honoured by
+// the builtin Output.printString. local 0 = i, local 1 = length.
+const OUTPUT_PRINT_STRING_BRIDGE: VmFunction = {
+  name: "Output.printString",
+  labels: { LOOP: 6, END: 21 },
+  nVars: 2,
+  opBase: 0,
+  operations: [
+    { op: "function", name: "Output.printString", nVars: 2 },
+    { op: "push", segment: "argument", offset: 0 },
+    { op: "call", name: "String.length", nArgs: 1 },
+    { op: "pop", segment: "local", offset: 1 },
+    { op: "push", segment: "constant", offset: 0 },
+    { op: "pop", segment: "local", offset: 0 },
+    { op: "label", label: "LOOP" },
+    { op: "push", segment: "local", offset: 0 },
+    { op: "push", segment: "local", offset: 1 },
+    { op: "eq" },
+    { op: "if-goto", label: "END" },
+    { op: "push", segment: "argument", offset: 0 },
+    { op: "push", segment: "local", offset: 0 },
+    { op: "call", name: "String.charAt", nArgs: 2 },
+    { op: "call", name: "Output.printChar", nArgs: 1 },
+    { op: "pop", segment: "temp", offset: 0 },
+    { op: "push", segment: "local", offset: 0 },
+    { op: "push", segment: "constant", offset: 1 },
+    { op: "add" },
+    { op: "pop", segment: "local", offset: 0 },
+    { op: "goto", label: "LOOP" },
+    { op: "label", label: "END" },
+    { op: "push", segment: "constant", offset: 0 },
+    { op: "return" },
+  ],
+};
+
 export interface ParsedVmFile {
   name: string;
   instructions: VmInstruction[];
@@ -578,6 +614,13 @@ export class Vm {
       !this.functionMap[ARRAY_DISPOSE_BRIDGE.name]
     ) {
       this.functionMap[ARRAY_DISPOSE_BRIDGE.name] = ARRAY_DISPOSE_BRIDGE;
+    }
+    if (
+      this.functionMap["String.charAt"] &&
+      !this.functionMap[OUTPUT_PRINT_STRING_BRIDGE.name]
+    ) {
+      this.functionMap[OUTPUT_PRINT_STRING_BRIDGE.name] =
+        OUTPUT_PRINT_STRING_BRIDGE;
     }
 
     if (this.functionMap[SYS_INIT.name]) {

--- a/simulator/src/vm/vm.ts
+++ b/simulator/src/vm/vm.ts
@@ -922,7 +922,7 @@ export class Vm {
         that: {
           base: THAT,
           count: 1,
-          values: [this.memory.THAT],
+          values: [...this.memory.map((_, v) => v, THAT, THAT + 1)],
         },
         frame: {
           ARG,

--- a/web/src/pages/compiler.tsx
+++ b/web/src/pages/compiler.tsx
@@ -98,6 +98,7 @@ export const Compiler = () => {
         files[file.name.replace(".jack", "")] = await file.text();
       }
     }
+    loadRef.current.value = "";
     actions.loadFiles(files);
   };
 

--- a/web/src/shell/Monaco.tsx
+++ b/web/src/shell/Monaco.tsx
@@ -97,6 +97,7 @@ export const Monaco = ({
   const { theme } = useContext(AppContext);
   const monaco = useRef<typeof monacoT>();
   const [height, setHeight] = useState(0);
+  const [editorReady, setEditorReady] = useState(false);
 
   const editor = useRef<monacoT.editor.IStandaloneCodeEditor>();
   const decorations = useRef<string[]>([]);
@@ -207,6 +208,7 @@ export const Monaco = ({
       });
       const model = editor.current?.getModel();
       model?.setEOL(monacoT.editor.EndOfLineSequence.LF);
+      setEditorReady(true);
     },
     [codeTheme],
   );
@@ -255,7 +257,7 @@ export const Monaco = ({
         severity: 8, // monacoT.MarkerSeverity.Error,
       },
     ]);
-  }, [error, editor, monaco, language]);
+  }, [error, language, editorReady]);
 
   const onValueChange = (v = "") => {
     calculateHeight();

--- a/web/src/shell/file_select.tsx
+++ b/web/src/shell/file_select.tsx
@@ -224,6 +224,8 @@ export const FilePicker = () => {
       });
     }
 
+    loadRef.current.value = "";
+
     filePicker[Selected].current?.(files.length == 1 ? files[0] : files);
     filePicker.close();
   };

--- a/web/src/shell/header.tsx
+++ b/web/src/shell/header.tsx
@@ -50,17 +50,15 @@ const guideLinks: Record<string, string> = {
 
 const GUIDE_NOT_AVAILABLE_MESSAGE = "Guide not available for this tool";
 
-async function openGuide(context: HeaderButtonContext) {
-  if (!guideLinks[context.pathname]) {
-    context.baseContext.setStatus(GUIDE_NOT_AVAILABLE_MESSAGE);
-    return;
-  }
+function openGuide(context: HeaderButtonContext) {
   const pdfLink = guideLinks[context.pathname];
-  const response = await fetch(pdfLink);
-  if (response.status === 404) {
+  if (!pdfLink) {
     context.baseContext.setStatus(GUIDE_NOT_AVAILABLE_MESSAGE);
     return;
   }
+  // Must call window.open synchronously inside the click handler — any
+  // intervening await drops the user-gesture flag and the popup blocker
+  // silently denies the open.
   window.open(pdfLink, "_blank", "width=1000,height=800");
 }
 


### PR DESCRIPTION
## Summary

Nine bug fixes burning down the open-issues triage list. Each commit is independently reviewable and carries its own `Closes #` trailer.

| # | Closes | Fix |
|---|--------|-----|
| 1 | #629 | Memory.deAlloc hang: alloc now unlinks non-head free blocks; deAlloc pushes to head (matches reference impl) |
| 2 | #608 | useStateInitializer syncs during render so chip switches don't leave Monaco a stale value/path mismatch on the undo stack |
| 3 | #644 | VM debug `that:` reads memory[THAT..], not the THAT pointer itself |
| 4 | #558 | Open Guide PDF synchronously so the popup blocker doesn't silently deny it |
| 5 | #485 | Initial Jack error markers wired after Monaco's async mount |
| 6 | #542 | Output.printString bridges to user-supplied String.length / String.charAt (Project 12) |
| 7 | #570 | Hardware Simulator initialize awaits loadChip and stops clearing the auto-loaded chip |
| 8 | #604 | Timer resets _steps_actual on each run so the dynamic budget doesn't carry over |
| 9 | #583 | Reset `<input type="file">` value after load so re-selecting the same file fires change |

## Likely also fixed

The file-input change from #583 has the same root cause as several other open reports about re-loading the same file; closed as duplicates after review:

- #524 — Can't update an already opened local file in the cpu emulator
- #544 — Cannot load asm file twice in a row
- #577 — Updated local .hack file under the same name will not refresh the content
